### PR TITLE
Add version.py and exec in setup.py and docs conf.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ author = "Neural Magic"
 # The full version, including alpha/beta/rc tags
 version = "unknown"
 version_major_minor = version
-# load and overwrite version info from sparseml package
+# load and overwrite version info from sparsify package
 exec(open(os.path.join(os.pardir, os.pardir, "src", "sparsify", "version.py")).read())
 release = version
 version = version_major_minor

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,8 +13,6 @@
 import os
 import sys
 
-from sparsezoo import __version__
-
 sys.path.insert(0, os.path.abspath("../.."))
 
 
@@ -28,9 +26,13 @@ copyright = (
 author = "Neural Magic"
 
 # The full version, including alpha/beta/rc tags
-ver_major, ver_minor, ver_bug = __version__.split(".")
-version = f"{ver_major}.{ver_minor}"
-release = __version__
+version = "unknown"
+version_major_minor = version
+# load and overwrite version info from sparseml package
+exec(open(os.path.join(os.pardir, os.pardir, "src", "sparsify", "version.py")).read())
+release = version
+version = version_major_minor
+print(f"loaded versions from src/sparsify/version.py and set to {release}, {version}")
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ from setuptools import find_packages, setup
 version = "unknown"
 version_major_minor = version
 # load and overwrite version info from sparseml package
-exec(open(os.path.join("src", "sparseml", "version.py")).read())
-print(f"loaded version {version} from src/sparseml/version.py")
+exec(open(os.path.join("src", "sparsify", "version.py")).read())
+print(f"loaded version {version} from src/sparsify/version.py")
 
 _PACKAGE_NAME = "sparsify"
 _NIGHTLY = "nightly" in sys.argv

--- a/setup.py
+++ b/setup.py
@@ -12,24 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 from datetime import date
 from sys import platform
 from typing import Dict, List, Tuple
+
 from setuptools import find_packages, setup
 
-from sparsify import __version__
 
+version = "unknown"
+version_major_minor = version
+# load and overwrite version info from sparseml package
+exec(open(os.path.join("src", "sparseml", "version.py")).read())
+print(f"loaded version {version} from src/sparseml/version.py")
 
 _PACKAGE_NAME = "sparsify"
-_VERSION = __version__
-_VERSION_MAJOR, _VERSION_MINOR, _VERSION_BUG = _VERSION.split(".")
-_VERSION_MAJOR_MINOR = f"{_VERSION_MAJOR}.{_VERSION_MINOR}"
 _NIGHTLY = "nightly" in sys.argv
 
 if _NIGHTLY:
     _PACKAGE_NAME += "-nightly"
-    _VERSION += "." + date.today().strftime("%Y%m%d")
+    version += "." + date.today().strftime("%Y%m%d")
     # remove nightly param so it does not break bdist_wheel
     sys.argv.remove("nightly")
 
@@ -44,8 +47,8 @@ _deps = [
 ]
 
 _nm_deps = [
-    f"{'sparsezoo-nightly' if _NIGHTLY else 'sparsezoo'}~={_VERSION_MAJOR_MINOR}",
-    f"{'sparseml-nightly' if _NIGHTLY else 'sparseml'}~={_VERSION_MAJOR_MINOR}",
+    f"{'sparsezoo-nightly' if _NIGHTLY else 'sparsezoo'}~={version_major_minor}",
+    f"{'sparseml-nightly' if _NIGHTLY else 'sparseml'}~={version_major_minor}",
 ]
 
 
@@ -95,7 +98,7 @@ def _setup_long_description() -> Tuple[str, str]:
 
 setup(
     name=_PACKAGE_NAME,
-    version=_VERSION,
+    version=version,
     author="Neuralmagic, Inc.",
     author_email="support@neuralmagic.com",
     description=(

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ from setuptools import find_packages, setup
 
 version = "unknown"
 version_major_minor = version
-# load and overwrite version info from sparseml package
+# load and overwrite version info from sparsify package
 exec(open(os.path.join("src", "sparsify", "version.py")).read())
 print(f"loaded version {version} from src/sparsify/version.py")
 

--- a/src/sparsify/version.py
+++ b/src/sparsify/version.py
@@ -16,7 +16,14 @@
 Functionality for storing and setting the version info for SparseML
 """
 
-__all__ = ["__version__"]
+__all__ = [
+    "__version__",
+    "version",
+    "version_major",
+    "version_minor",
+    "version_bug",
+    "version_major_minor",
+]
 __version__ = "0.2.0"
 
 version = __version__

--- a/src/sparsify/version.py
+++ b/src/sparsify/version.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Functionality for storing and setting the version info for SparseML
+Functionality for storing and setting the version info for Sparsify
 """
 
 __all__ = [

--- a/src/sparsify/version.py
+++ b/src/sparsify/version.py
@@ -13,18 +13,12 @@
 # limitations under the License.
 
 """
-Functionality for handling the backend of Sparsify to benchmark and sparsify
-neural networks
+Functionality for storing and setting the version info for SparseML
 """
 
-# flake8: noqa
-# isort: skip_file
-
+__all__ = ["__version__"]
 __version__ = "0.2.0"
 
-# be sure to import all logging first and at the root
-# this keeps other loggers in nested files creating from the root logger setups
-from .log import *
-
-from .version import *
-from .app import *
+version = __version__
+version_major, version_minor, version_bug = version.split(".")
+version_major_minor = f"{version_major}.{version_minor}"


### PR DESCRIPTION
Changing so that we don't have a requirement of the user setting the pythonpath for builds and docs to work with new version