### PR TITLE
Accept configurable pytest args from env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ DOCDIR := docs
 MDCHECKGLOBS := 'docs/**/*.md' 'docs/**/*.rst' 'examples/**/*.md' 'notebooks/**/*.md' 'scripts/**/*.md'
 MDCHECKFILES := CODE_OF_CONDUCT.md CONTRIBUTING.md DEVELOPING.md README.md
 SPARSEZOO_TEST_MODE := "true"
+PYTEST_ARGS ?= ""
 
 # run checks on all files for the repo
 quality:
@@ -35,7 +36,7 @@ style:
 # run tests for the repo
 test:
 	@echo "Running python tests";
-	@pytest;
+	@pytest $(PYTEST_ARGS);
 
 # create docs
 docs:


### PR DESCRIPTION
Add an optional variable to the Makefile to allow passing custom flags to the pytest command.