### PR TITLE
Update: Supported `Python` versions in docs

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Developing Sparsify
 
-Sparsify is developed and tested using Python 3.6+.
+Sparsify is developed and tested using Python 3.6-3.9.
 To develop Sparsify, you will also need the development dependencies and to follow the styling guidelines.
 
 Here's some details to get started.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Coming soon!
 
 ## Installation
 
-This repository is tested on Python 3.6+, Linux/Debian systems, and Chrome 87+.
+This repository is tested on Python 3.6-3.9, Linux/Debian systems, and Chrome 87+.
 It is recommended to install in a [virtual environment](https://docs.python.org/3/library/venv.html) to keep your system in order.
 
 Install with pip using:


### PR DESCRIPTION
The goal of this PR is to make supported Python versions explicit in all our docs

* `Python 3.6+` --> `Python 3.6-3.9`