### PR TITLE
Limit required python versions to supported ones

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ setup(
     install_requires=_setup_install_requires(),
     extras_require=_setup_extras(),
     entry_points=_setup_entry_points(),
-    python_requires=">=3.6.0",
+    python_requires=">=3.6.0,<3.10",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Update required python versions to match supported ones, also gives a better error message when using wrong Python