### PR TITLE
CLI + Base Structure for `sparsify.package`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ _deps = [
     "Flask-Cors>=3.0.0",
     "marshmallow>=3.0.0",
     "peewee>=3.0.0",
+    "click==8.0.0",
 ]
 
 _nm_deps = [
@@ -88,7 +89,12 @@ def _setup_extras() -> Dict:
 
 
 def _setup_entry_points() -> Dict:
-    return {"console_scripts": ["sparsify=sparsify.app:main"]}
+    return {
+        "console_scripts": [
+            "sparsify=sparsify.app:main",
+            "sparsify.package=sparsify.package_.cli:main",
+        ]
+    }
 
 
 def _setup_long_description() -> Tuple[str, str]:

--- a/src/sparsify/__init__.py
+++ b/src/sparsify/__init__.py
@@ -26,7 +26,7 @@ from .log import *
 
 from .version import *
 from .app import *
-
+from .package_ import *
 
 try:
     from sparsezoo.package import check_package_version as _check_package_version

--- a/src/sparsify/package_/__init__.py
+++ b/src/sparsify/package_/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# flake8: noqa
+
+from .main import *

--- a/src/sparsify/package_/cli.py
+++ b/src/sparsify/package_/cli.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+❯ sparsify.package --help
+Usage: sparsify.package [OPTIONS] [DIRECTORY]
+
+  Utility to fetch a deployment directory for a task based on a optimizing-
+  metric
+
+Options:
+  --task [ic|image-classification|image_classification|classification|od|object
+  -detection|object_detection|detection|segmentation|qa|question-answering
+  |question_answering|text-classification|text_classification|glue|sentiment
+  |sentiment_analysis|sentiment-analysis|token-classification|token_classification
+  |ner|named-entity-recognition|named_entity_recognition]
+                                  The task to find model for NOTE: This
+                                  argument is mutually exclusive with dataset
+  --dataset TEXT                  The public dataset used to train this model
+                                  NOTE: This argument is mutually exclusive
+                                  with task
+  --optimizing-metric [accuracy|f1|recall|mAP|latency|file_size|memory_usage]
+                                  The criterion to search model for
+  --scenario [VNNI]               The deployment scenarios to choose from
+                                  [default: VNNI]
+  --help                          Show this message and exit.
+"""
+
+from pathlib import Path
+
+import click
+from sparsify.package_.utils import DEPLOYMENT_SCENARIOS, METRICS, TASKS
+from sparsify.package_.utils.cli_helpers import NotRequiredIf, OptionEatAllArguments
+
+
+def _create_dir_callback(ctx, param, value):
+    return Path(value).mkdir(exist_ok=True)
+
+
+@click.command()
+@click.argument(
+    "directory",
+    type=click.Path(dir_okay=True, file_okay=False),
+    default="deployment_directory",
+    callback=_create_dir_callback,
+)
+@click.option(
+    "--task",
+    type=click.Choice(TASKS, case_sensitive=False),
+    cls=NotRequiredIf,
+    not_required_if="dataset",
+    help="The task to find model for",
+)
+@click.option(
+    "--dataset",
+    type=str,
+    cls=NotRequiredIf,
+    not_required_if="task",
+    help="The public dataset used to train this model",
+)
+@click.option(
+    "--optimizing-metric",
+    type=click.Choice(METRICS, case_sensitive=False),
+    default="accuracy",
+    cls=OptionEatAllArguments,
+    help="The criterion to search model for",
+)
+@click.option(
+    "--scenario",
+    type=click.Choice(DEPLOYMENT_SCENARIOS, case_sensitive=False),
+    default=DEPLOYMENT_SCENARIOS[0] if len(DEPLOYMENT_SCENARIOS) else "VNNI",
+    help="The deployment scenarios to choose from",
+    show_default=True,
+)
+def main(*args, **kwargs):
+    """
+    Utility to fetch a deployment directory for a task based on a
+    optimizing-metric
+    """
+    print(kwargs)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sparsify/package_/main.py
+++ b/src/sparsify/package_/main.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    "package",
+]
+
+from typing import Iterable, Union
+
+
+def package(task: str, optimizing_metric: Union[str, Iterable[str]]):
+    pass

--- a/src/sparsify/package_/utils/__init__.py
+++ b/src/sparsify/package_/utils/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# flake8: noqa
+
+from .constants import *
+from .helpers import *

--- a/src/sparsify/package_/utils/cli_helpers.py
+++ b/src/sparsify/package_/utils/cli_helpers.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+
+
+class NotRequiredIf(click.Option):
+    """
+    A click.Option that creates Mutually exclusive args. Click does not support
+    Mutually Exclusive args. This class is a work around for this limitation.
+    Repurposed from https://stackoverflow.com/a/44349292
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.not_required_if = kwargs.pop("not_required_if")
+        assert self.not_required_if, "'not_required_if' parameter required"
+        kwargs["help"] = (
+            kwargs.get("help", "")
+            + " NOTE: This argument is mutually exclusive with %s"
+            % self.not_required_if
+        ).strip()
+        super(NotRequiredIf, self).__init__(*args, **kwargs)
+
+    def handle_parse_result(self, ctx, opts, args):
+        we_are_present = self.name in opts
+        other_present = self.not_required_if in opts
+
+        if other_present:
+            if we_are_present:
+                raise click.UsageError(
+                    "Illegal usage: `%s` is mutually exclusive with `%s`"
+                    % (self.name, self.not_required_if)
+                )
+            else:
+                self.prompt = None
+
+        return super(NotRequiredIf, self).handle_parse_result(ctx, opts, args)
+
+
+class OptionEatAllArguments(click.Option):
+    """
+    A click.Option that eats all arguments. Click does not support nargs=-1 for
+    options. This class is a work around for this limitation.
+    Repurposed from https://stackoverflow.com/a/48394004
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.save_other_options = kwargs.pop("save_other_options", True)
+        nargs = kwargs.pop("nargs", -1)
+        assert nargs == -1, "nargs, if set, must be -1 not {}".format(nargs)
+        super(OptionEatAllArguments, self).__init__(*args, **kwargs)
+        self._previous_parser_process = None
+        self._eat_all_parser = None
+
+    def add_to_parser(self, parser, ctx):
+        def parser_process(value, state):
+            # method to hook to the parser.process
+            done = False
+            value = [value]
+            if self.save_other_options:
+                # grab everything up to the next option
+                while state.rargs and not done:
+                    for prefix in self._eat_all_parser.prefixes:
+                        if state.rargs[0].startswith(prefix):
+                            done = True
+                    if not done:
+                        value.append(state.rargs.pop(0))
+            else:
+                # grab everything remaining
+                value += state.rargs
+                state.rargs[:] = []
+            value = tuple(value)
+
+            # call the actual process
+            self._previous_parser_process(value, state)
+
+        retval = super(OptionEatAllArguments, self).add_to_parser(parser, ctx)
+        for name in self.opts:
+            our_parser = parser._long_opt.get(name) or parser._short_opt.get(name)
+            if our_parser:
+                self._eat_all_parser = our_parser
+                self._previous_parser_process = our_parser.process
+                our_parser.process = parser_process
+                break
+
+        return retval

--- a/src/sparsify/package_/utils/constants.py
+++ b/src/sparsify/package_/utils/constants.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    "TASKS",
+    "METRICS",
+    "DEPLOYMENT_SCENARIOS",
+]
+
+TASKS = [
+    "ic",
+    "image-classification",
+    "image_classification",
+    "classification",
+    "od",
+    "object-detection",
+    "object_detection",
+    "detection",
+    "segmentation",
+    "qa",
+    "question-answering",
+    "question_answering",
+    "text-classification",
+    "text_classification",
+    "glue",
+    "sentiment",
+    "sentiment_analysis",
+    "sentiment-analysis",
+    "token-classification",
+    "token_classification",
+    "ner",
+    "named-entity-recognition",
+    "named_entity_recognition",
+]
+METRICS = [
+    "accuracy",
+    "f1",
+    "recall",
+    "mAP",
+    "latency",
+    "file_size",
+    "memory_usage",
+]
+
+DEPLOYMENT_SCENARIOS = [
+    "VNNI",
+]

--- a/src/sparsify/package_/utils/helpers.py
+++ b/src/sparsify/package_/utils/helpers.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sparsezoo import Model
+
+
+__all__ = ["download_directory_from_stub"]
+
+
+def download_directory_from_stub(stub: str):
+    """
+    Download deployment directory from stub and return it's local path
+
+    :param stub: A valid SparseZoo stub
+    :return: The local path of the deployment directory for the stub
+    """
+    return Model(stub).deployment.path

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# flake8: noqa

--- a/tests/sparsify/__init__.py
+++ b/tests/sparsify/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# flake8: noqa

--- a/tests/sparsify/package_/__init__.py
+++ b/tests/sparsify/package_/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# flake8: noqa

--- a/tests/sparsify/package_/utils/__init__.py
+++ b/tests/sparsify/package_/utils/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/sparsify/package_/utils/test_helpers.py
+++ b/tests/sparsify/package_/utils/test_helpers.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+from sparsify.package_.utils import _download_directory_from_stub  # noqa
+
+
+_CV_STUBS = [
+    "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95_quant-none",
+]
+
+_NLP_STUBS = [
+    "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad"
+    "/pruned95_obs_quant-none"
+]
+
+_BASE_FILES = {"model.onnx"}
+_ALL_FILES = _BASE_FILES.union(("config.json", "tokenizer.json"))
+
+_STUBS_AND_EXPECTED_FILES = [(_stub, _BASE_FILES) for _stub in _CV_STUBS]
+_STUBS_AND_EXPECTED_FILES.extend((_stub, _ALL_FILES) for _stub in _NLP_STUBS)
+
+
+def _get_file_dict(
+    folder_path: str,
+    recursive: bool = True,
+) -> Dict[str, str]:
+    """
+    Returns a mapping of filename --> absolute file path, for
+    all files within a given folder; note searches for files
+    recursively by default
+
+    :param folder_path: Path to a directory
+    :param recursive: if Truthy then folder_path is searched recursively
+    """
+    folder_path = Path(folder_path)
+    file_dict = {}
+    for file in folder_path.iterdir():
+        if file.is_file():
+            file_dict[file.name] = file.absolute()
+        elif recursive:
+            file_dict.update(_get_file_dict(file, recursive=recursive))
+    return file_dict
+
+
+@pytest.mark.parametrize("stub, expected_files", _STUBS_AND_EXPECTED_FILES)
+def test_model_directory_exists(stub, expected_files):
+    model_dir = _download_directory_from_stub(stub)
+
+    assert isinstance(model_dir, str)
+    assert Path(model_dir).is_dir()
+
+    downloaded_files = _get_file_dict(folder_path=model_dir)
+
+    for filename in expected_files:
+        assert filename in downloaded_files


### PR DESCRIPTION
* Setup directory Structure
* `from sparsify import package` importable + callable function
* A constants file with supported tasks, criterions, and deployment scenarios (Should probably converted to `Enums` or something better than `python lists`)
* Add `click` as a required dependency
* Additional CLI helpers for updated acceptance criterion
* `sparsify.package` cli utility
* A download directory from stub function
* setup test directory
* tests for the added function across both `CV` and `NLP` use cases