### PR TITLE
`sparsify.package` naive search

### DIFF
--- a/src/sparsify/__init__.py
+++ b/src/sparsify/__init__.py
@@ -15,4 +15,5 @@
 # flake8: noqa
 # isort: skip_file
 
+from . import package as package_module
 from .package import *

--- a/src/sparsify/package/cli.py
+++ b/src/sparsify/package/cli.py
@@ -52,7 +52,7 @@ from typing import Any, Dict
 
 import click
 from sparsify import package
-from sparsify.utils import DATASETS, DEPLOYMENT_SCENARIOS, METRICS, TASKS
+from sparsify.utils.constants import DATASETS, DEPLOYMENT_SCENARIOS, METRICS, TASKS
 from sparsify.version import __version__
 
 
@@ -100,7 +100,6 @@ def _create_dir_callback(ctx, param, value):
     "--scenario",
     "-s",
     type=click.Choice(DEPLOYMENT_SCENARIOS, case_sensitive=False),
-    default=DEPLOYMENT_SCENARIOS[0] if len(DEPLOYMENT_SCENARIOS) else "VNNI",
     help="The deployment scenarios to choose from",
     show_default=True,
 )
@@ -116,7 +115,7 @@ def parse_args(**kwargs) -> Dict[str, Any]:
          `sparsify.package --t ic -m accuracy -m compression -s VNNI`
     """
     if not (kwargs.get("task") or kwargs.get("dataset")):
-        raise ValueError("At-least one of the `task` or `dataset`")
+        raise ValueError("At-least one of the `task` or `dataset` must be specified")
     _LOGGER.debug(f"{kwargs}")
     return kwargs
 

--- a/src/sparsify/package/main.py
+++ b/src/sparsify/package/main.py
@@ -11,15 +11,64 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
+from typing import List, Optional
+
+from sparsezoo import search_models
+from sparsify.utils.helpers import (
+    download_deployment_directory_from_stub,
+    infer_dataset_domain_subdomain,
+)
+
 
 __all__ = [
     "package",
 ]
 
+_LOGGER = logging.getLogger(__name__)
 
-def package(*args, **kwargs):
+
+def package(
+    directory: Optional[str] = None,
+    task: Optional[str] = None,
+    dataset: Optional[str] = None,
+    scenario: Optional[str] = None,
+    *args,
+    **kwargs,
+):
     """
     A function that returns a deployment directory given the task or dataset,
     and an optimizing criterion
+
+    :param directory: str A local existing directory path to download the deployment
+        artifacts to
+    :param task: str A supported task
+    :param dataset: str The public dataset this model was trained for
+    :param scenario: Optional[str] `VNNI` or `vnni for a VNNI compatible machine
     """
-    raise NotImplementedError
+
+    dataset, domain, subdomain = infer_dataset_domain_subdomain(
+        dataset=dataset, task=task
+    )
+
+    stubs: List[str] = search_models(
+        domain=domain,
+        sub_domain=subdomain,
+        dataset=dataset,
+        return_stubs=True,
+    )
+
+    if scenario is not None:
+        stubs = [stub for stub in stubs if scenario.lower() in stub]
+
+    if not stubs:
+        raise ValueError(
+            f"Could not find any relevant stubs for the given task, dataset "
+            f"and deployment scenario: {task, dataset, scenario}"
+        )
+    # naive implementation download first stub
+    deployment_path = download_deployment_directory_from_stub(
+        stub=stubs[0], directory=directory
+    )
+    _LOGGER.info(f"Deployment artifacts downloaded to {deployment_path}")
+    return deployment_path

--- a/src/sparsify/utils/constants.py
+++ b/src/sparsify/utils/constants.py
@@ -40,7 +40,6 @@ METRICS = [
 
 DEPLOYMENT_SCENARIOS = [
     "VNNI",
-    "NO_VNNI",
 ]
 
 TASK_REGISTRY = {

--- a/src/sparsify/utils/helpers.py
+++ b/src/sparsify/utils/helpers.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Optional, Tuple
+
+from sparsezoo import Model
+from sparsify.utils.constants import DATASET_REGISTRY, TASK_REGISTRY, TaskInfo
+
+
+__all__ = [
+    "download_deployment_directory_from_stub",
+    "infer_dataset_domain_subdomain",
+]
+
+
+def download_deployment_directory_from_stub(stub: str, directory: Optional[str] = None):
+    """
+    Download deployment directory from stub and return it's local path
+
+    :param stub: A valid SparseZoo stub
+    :param directory: An optional local path to download deployment artifacts to
+    :return: The local path of the deployment directory for the stub
+    """
+
+    model = (
+        Model(source=stub, download_path=directory) if directory else Model(source=stub)
+    )
+    model.deployment.download()
+    return model.deployment.path
+
+
+def infer_dataset_domain_subdomain(
+    dataset: Optional[str],
+    task: Optional[str],
+) -> Tuple[Optional[str], str, str]:
+    """
+    Infer dataset, domain and subdomain from the given dataset and task. Note
+    at-least one out of dataset and task must be provided
+
+    :param dataset: Optional[str] An optional dataset name, must be specified
+        if task not given
+    :param task: Optional[str] An optional task name, must be specified
+        if task not specified
+    :return: A tuple of the format (dataset, domain, subdomain)
+    """
+    task_info: Optional[TaskInfo] = TASK_REGISTRY.get(task)
+    dataset_task_info: Optional[TaskInfo] = DATASET_REGISTRY.get(dataset)
+    if not task_info and not dataset_task_info:
+        raise ValueError(
+            f"Could not find any info for the given (task, dataset): {task, dataset}"
+        )
+    if task_info and dataset_task_info:
+        if task_info.domain != dataset_task_info.domain:
+            raise ValueError(
+                f"Domain mismatch for the given (task, dataset): {task, dataset}"
+            )
+    domain = task_info.domain if task_info else dataset_task_info.domain
+    subdomain = task_info.subdomain if task_info else dataset_task_info.subdomain
+    dataset = dataset if dataset_task_info else None
+    return dataset, domain, subdomain

--- a/tests/sparsify/package/test_package.py
+++ b/tests/sparsify/package/test_package.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+
+from sparsify import package
+
+
+@patch("sparsify.package_module.main.search_function")
+@patch("sparsify.package_module.main.download_deployment_directory_from_stub")
+def test_valid_execution(download_function, search_function):
+    download_function.return_value = ""
+    search_function.return_value = ["zoo://vnni"]
+
+    assert package(directory=None, task="ic") == ""
+    assert package(task="ic") == ""
+    assert package(dataset="imagenet") == ""
+    assert package(dataset="imagenet", scenario="vnni") == ""
+    assert package(task="qa", dataset="squad", scenario=None) == ""
+    assert package(task="qa", dataset="squad", scenario="vnni") == ""
+
+
+@patch("sparsify.package_module.main.search_function")
+def test_value_error(search_function):
+    # search results empty
+    search_function.return_value = []
+    with pytest.raises(ValueError):
+        package(task="ic")
+
+    # deployment scenario not found
+    search_function.return_value = ["zoo://blah"]
+    with pytest.raises(ValueError):
+        package(task="ic", scenario="vnni")
+
+    # at-least dataset or task must be specified
+    with pytest.raises(ValueError):
+        package(scenario="vnni")
+
+    # at-least dataset or task must be specified
+    with pytest.raises(ValueError):
+        package()

--- a/tests/sparsify/package/test_package.py
+++ b/tests/sparsify/package/test_package.py
@@ -19,7 +19,7 @@ import pytest
 from sparsify import package
 
 
-@patch("sparsify.package_module.main.search_function")
+@patch("sparsify.package_module.main.search_models")
 @patch("sparsify.package_module.main.download_deployment_directory_from_stub")
 def test_valid_execution(download_function, search_function):
     download_function.return_value = ""
@@ -33,7 +33,7 @@ def test_valid_execution(download_function, search_function):
     assert package(task="qa", dataset="squad", scenario="vnni") == ""
 
 
-@patch("sparsify.package_module.main.search_function")
+@patch("sparsify.package_module.main.search_models")
 def test_value_error(search_function):
     # search results empty
     search_function.return_value = []

--- a/tests/sparsify/utils/__init__.py
+++ b/tests/sparsify/utils/__init__.py
@@ -11,7 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# flake8: noqa
-
-from .helpers import *

--- a/tests/sparsify/utils/test_helpers.py
+++ b/tests/sparsify/utils/test_helpers.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+from sparsify.utils.helpers import (
+    download_deployment_directory_from_stub,
+    infer_dataset_domain_subdomain,
+)
+
+
+_CV_STUBS = [
+    "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet"
+    "/pruned95_quant-none",
+]
+
+_NLP_STUBS = [
+    "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad"
+    "/pruned95_obs_quant-none"
+]
+
+_BASE_FILES = {"model.onnx"}
+_ALL_FILES = _BASE_FILES.union(("config.json", "tokenizer.json"))
+
+_STUBS_AND_EXPECTED_FILES = [(_stub, _BASE_FILES) for _stub in _CV_STUBS]
+_STUBS_AND_EXPECTED_FILES.extend((_stub, _ALL_FILES) for _stub in _NLP_STUBS)
+
+
+def _get_file_dict(
+    folder_path: str,
+    recursive: bool = True,
+) -> Dict[str, str]:
+    """
+    Returns a mapping of filename --> absolute file path, for
+    all files within a given folder; note searches for files
+    recursively by default
+
+    :param folder_path: Path to a directory
+    :param recursive: if Truthy then folder_path is searched recursively
+    """
+    folder_path = Path(folder_path)
+    file_dict = {}
+    for file in folder_path.iterdir():
+        if file.is_file():
+            file_dict[file.name] = file.absolute()
+        elif recursive:
+            file_dict.update(_get_file_dict(file, recursive=recursive))
+    return file_dict
+
+
+@pytest.mark.parametrize("stub, expected_files", _STUBS_AND_EXPECTED_FILES)
+def test_model_deployment_directory_exists(stub, expected_files):
+    model_dir = download_deployment_directory_from_stub(stub)
+
+    assert isinstance(model_dir, str)
+    assert Path(model_dir).is_dir()
+
+    downloaded_files = _get_file_dict(folder_path=model_dir)
+
+    for filename in expected_files:
+        assert filename in downloaded_files
+
+
+@pytest.mark.parametrize(
+    "dataset, task, expected",
+    [
+        (None, "ic", (None, "cv", "classification")),
+        ("imagenette", "ic", ("imagenette", "cv", "classification")),
+        ("blah", "ic", (None, "cv", "classification")),
+        ("imagenet", "blah", ("imagenet", "cv", "classification")),
+        ("coco", "segmentation", ("coco", "cv", "segmentation")),
+        ("coco", "object_detection", ("coco", "cv", "detection")),
+    ],
+)
+def test_infer_dataset_domain_subdomain(dataset, task, expected):
+    assert infer_dataset_domain_subdomain(dataset=dataset, task=task) == expected
+
+
+@pytest.mark.parametrize(
+    "dataset, task",
+    [
+        ("mnli", "classification"),
+        ("coco", "text_classification"),
+        ("blah", "blah"),
+    ],
+)
+def test_infer_dataset_domain_subdomain_raises_value_error(dataset, task):
+    with pytest.raises(ValueError):
+        infer_dataset_domain_subdomain(dataset=dataset, task=task)


### PR DESCRIPTION
This PR is second in a series of PRs scoped out for `sparsify.package`, `alpha` release:

This PR includes the following:

- [X] A naive "working" `package` function that works with the cli + normal invocation
- [X] Support for searching zoo with `task, dataset and a deployment scenario`, (Only `vnni` supported for now, )
- [X] Broke the functionality into three main functions and added tests for all three