### PR TITLE
Fixing available_ml_engines crash

### DIFF
--- a/src/sparsify/utils/system.py
+++ b/src/sparsify/utils/system.py
@@ -59,11 +59,12 @@ def available_ml_engines() -> List[str]:
     if deepsparse is not None:
         engines.append("deepsparse")
 
-    ort_providers = onnxruntime.get_available_providers()
-    if "CPUExecutionProvider" in ort_providers:
-        engines.append("ort_cpu")
-    if "CUDAExecutionProvider" in ort_providers:
-        engines.append("ort_gpu")
+    if onnxruntime is not None:
+        ort_providers = onnxruntime.get_available_providers()
+        if "CPUExecutionProvider" in ort_providers:
+            engines.append("ort_cpu")
+        if "CUDAExecutionProvider" in ort_providers:
+            engines.append("ort_gpu")
 
     return engines
 


### PR DESCRIPTION
Addresses issue in #121 

When onnxruntime is not installed, the `available_ml_engines()` function would try to access a method on `None`.