### PR TITLE
Drop support for torch<1.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,11 +31,7 @@ version_nm_deps = f"{version_major_minor}.0"
 _PACKAGE_NAME = "sparsify" if is_release else "sparsify-nightly"
 
 
-_deps = [
-    "pydantic>=1.8.2",
-    "pyyaml>=5.0.0",
-    "click~=8.0.0",
-]
+_deps = ["pydantic>=1.8.2", "pyyaml>=5.0.0", "click~=8.0.0", "torch>=1.9.0"]
 _nm_deps = [
     f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_nm_deps}",
     f"{'sparseml' if is_release else 'sparseml-nightly'}[torchvision]~={version_nm_deps}",  # noqa E501

--- a/src/sparsify/auto/api/main.py
+++ b/src/sparsify/auto/api/main.py
@@ -58,6 +58,8 @@ def main():
 
         config = SparsificationTrainingConfig(**config_dict)
 
+    runner.export()
+
     # Conduct any generic post-processing and display results to user
     results = output.finalize()
     print(results)

--- a/src/sparsify/auto/api/main.py
+++ b/src/sparsify/auto/api/main.py
@@ -58,8 +58,6 @@ def main():
 
         config = SparsificationTrainingConfig(**config_dict)
 
-    runner.export()
-
     # Conduct any generic post-processing and display results to user
     results = output.finalize()
     print(results)

--- a/src/sparsify/auto/tasks/runner.py
+++ b/src/sparsify/auto/tasks/runner.py
@@ -24,15 +24,7 @@ from functools import wraps
 from typing import Dict, List, Optional, Tuple
 
 import torch
-
-
-try:
-    from torch.distributed.run import main as launch_ddp
-
-    import_ddp_error = None
-
-except ImportError as ddp_error:
-    import_ddp_error = ddp_error
+from torch.distributed.run import main as launch_ddp
 
 from pydantic import BaseModel
 from sparsify.auto.api import APIOutput, Metrics, SparsificationTrainingConfig
@@ -49,7 +41,7 @@ __all__ = [
     "TaskRunner",
 ]
 
-DDP_ENABLED = not (import_ddp_error or os.environ.get("NM_AUTO_DISABLE_DDP"))
+DDP_ENABLED = os.environ.get("NM_AUTO_DISABLE_DDP")
 MAX_RETRY_ATTEMPTS = os.environ.get("NM_MAX_SCRIPT_RETRY_ATTEMPTS", 3)  # default: 3
 MAX_MEMORY_STEPDOWNS = os.environ.get("NM_MAX_SCRIPT_MEMORY_STEPDOWNS", 10)
 SUPPORTED_TASKS = [

--- a/src/sparsify/auto/tasks/runner.py
+++ b/src/sparsify/auto/tasks/runner.py
@@ -41,7 +41,7 @@ __all__ = [
     "TaskRunner",
 ]
 
-DDP_ENABLED = os.environ.get("NM_AUTO_DISABLE_DDP")
+DDP_ENABLED = not (os.environ.get("NM_AUTO_DISABLE_DDP", False))
 MAX_RETRY_ATTEMPTS = os.environ.get("NM_MAX_SCRIPT_RETRY_ATTEMPTS", 3)  # default: 3
 MAX_MEMORY_STEPDOWNS = os.environ.get("NM_MAX_SCRIPT_MEMORY_STEPDOWNS", 10)
 SUPPORTED_TASKS = [


### PR DESCRIPTION
With this PR we are dropping support for torch<1.9. The existing API paths are kept as an optional path activated through the environment variable NM_AUTO_DISABLE_DDP, primarily for debugging.