### PR TITLE
Export only best model

### DIFF
--- a/src/sparsify/auto/api/main.py
+++ b/src/sparsify/auto/api/main.py
@@ -84,8 +84,10 @@ def main():
 
         iteration_idx += 1
 
-    # Conduct any generic post-processing and display results to user
-    runner.create_deployment_directory(best_n_models.index(max(best_n_models)))
+    # Export model and create deployment folder
+    best_iteration_idx = best_n_models.index(max(best_n_models))
+    runner.export(best_iteration_idx)
+    runner.create_deployment_directory(best_iteration_idx)
 
 
 if __name__ == "__main__":

--- a/src/sparsify/auto/api/main.py
+++ b/src/sparsify/auto/api/main.py
@@ -56,7 +56,7 @@ def main():
         runner = TaskRunner.create(config)
 
         # Execute integration run and return metrics
-        metrics = runner.run()
+        metrics = runner.train()
 
         # Move models from temporary directory to save directory, while only keeping
         # the best n models

--- a/src/sparsify/auto/tasks/image_classification/runner.py
+++ b/src/sparsify/auto/tasks/image_classification/runner.py
@@ -54,6 +54,7 @@ class ImageClassificationRunner(TaskRunner):
     train_hook = staticmethod(train_hook.callback)
     export_hook = staticmethod(export_hook.callback)
     sparseml_train_entrypoint = "sparseml.image_classification.train"
+    model_path = "checkpoint_path"
 
     def __init__(self, config: SparsificationTrainingConfig):
         super().__init__(config)

--- a/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
+++ b/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
@@ -63,6 +63,7 @@ class Yolov5Runner(TaskRunner):
     train_hook = staticmethod(train_hook)
     export_hook = staticmethod(export_hook)
     sparseml_train_entrypoint = "sparseml.yolov5.train"
+    export_model_kwarg = "weights"
 
     def __init__(self, config: SparsificationTrainingConfig):
         super().__init__(config)

--- a/src/sparsify/auto/tasks/runner.py
+++ b/src/sparsify/auto/tasks/runner.py
@@ -136,7 +136,6 @@ class TaskRunner:
 
     def __init__(self, config: SparsificationTrainingConfig):
         self._config = config
-        self.run_dir = SAVE_DIR.format(task=str(self.task))
 
         if self.export_model_kwarg is None:
             raise ValueError(

--- a/src/sparsify/auto/tasks/runner.py
+++ b/src/sparsify/auto/tasks/runner.py
@@ -133,6 +133,7 @@ class TaskRunner:
 
     def __init__(self, config: SparsificationTrainingConfig):
         self._config = config
+        self.run_dir = SAVE_DIR.format(task=str(self.task))
 
         # distributed training supported for torch>=1.9, as ddp error propagation was
         # introduced in 1.9
@@ -343,6 +344,13 @@ class TaskRunner:
         """
         Move output into target directory
         """
+        target_directory = os.path.join(
+            self.config.save_directory,
+            SAVE_DIR,
+            "run_artifacts",
+            f"iteration_{iteration_idx}",
+        )
+
         if not (self.completion_check("train") and self.completion_check("export")):
             warnings.warn(
                 "Run did not complete successfully. Output generated may not reflect "

--- a/src/sparsify/auto/tasks/transformers/runner.py
+++ b/src/sparsify/auto/tasks/transformers/runner.py
@@ -51,6 +51,7 @@ class _TransformersRunner(TaskRunner):
     """
 
     export_hook = staticmethod(export_hook)
+    export_model_kwarg = "model_path"
 
     def __init__(self, config: SparsificationTrainingConfig):
         super().__init__(config)


### PR DESCRIPTION
Currently, export is run after each train call. This PR updates the flow to only export the best model at the end

**Testing**
Covered by end to end tests