### PR TITLE
`sparsify.package` updates

### DIFF
--- a/src/sparsify/package/cli.py
+++ b/src/sparsify/package/cli.py
@@ -90,10 +90,10 @@ def _csv_callback(ctx, self, value):
     """
     current_metrics = []
     for metric in value.split(","):
-        normalized_metric = metric.lower().strip()
-        if normalized_metric not in METRICS:
-            raise ValueError(f"Specified metric {normalized_metric} is not supported")
-        current_metrics.append(normalized_metric)
+        metric_ = metric.lower().strip()
+        if metric_ not in METRICS:
+            raise ValueError(f"Specified metric {metric_} is not supported")
+        current_metrics.append(metric_)
     return current_metrics
 
 

--- a/src/sparsify/package/cli.py
+++ b/src/sparsify/package/cli.py
@@ -107,7 +107,6 @@ def _get_template(results: Mapping[str, Any], metrics: Iterable[str]):
         Relevant Stub: {stub}
     """
     model_metrics = results.get("metrics") or []
-    model_metrics = [abs(metric) for metric in model_metrics]
     metrics_info = (
         f"""
         Model Metrics: {list(zip(metrics, model_metrics))}

--- a/src/sparsify/package/main.py
+++ b/src/sparsify/package/main.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import Iterable, Optional, Union
+from typing import Any, Iterable, Mapping, Optional, Union
 
 import requests
 
@@ -33,7 +33,7 @@ def package(
     scenario: Optional[str] = None,
     optimizing_metric: Optional[Union[Iterable[str], str]] = None,
     **kwargs,
-) -> str:
+) -> Mapping[str, Any]:
     """
     A function that returns appropriate SparseZoo stub or deployment directory given
     the task or dataset, optimizing criterions and a deployment scenario
@@ -45,7 +45,7 @@ def package(
     :param scenario: Optional[str] `VNNI` or `vnni for a VNNI compatible machine
     :param optimizing_metric: Optional[List[str], str] representing different metrics
         to prioritize for when searching for models
-    :return: The appropriate stub based on specified arguments
+    :return: A dict type object with the relevant stub and model metrics
     """
     optimizing_metric = (
         [optimizing_metric] if isinstance(optimizing_metric, str) else optimizing_metric
@@ -57,7 +57,7 @@ def package(
         "scenario": scenario,
         "optimizing_metric": optimizing_metric,
     }
-
+    _LOGGER.info("Making a request to backend server")
     response = requests.get(
         url=get_backend_url(),
         headers={"Content-Type": "application/json"},


### PR DESCRIPTION
The following PR has 3 small changes:
 
 1) Improve output from `sparsify.package`, the output now also displays model metrics
 2) Update `--optimizing_metric` arg to take in a comma separated value for metrics over `click's multiple option`
 3) Update usage instructions accordingly
 
 Note: for local testing kindly set `SPARSIFY_BACKEND_URL` to the url of local backend server
 example: let's say the server runs on `http://0.0.0.0:8000` then  `export SPARSIFY_BACKEND_URL=http://0.0.0.0:8000`
 
 Depends on sparsify backend diff: https://github.com/neuralmagic/model-api-service/pull/1
 
 Tests: Manual testing + Automated test
 
 For manual test,
 
 - Export `SPARSIFY_BACKEND_URL=...`
 - Spin up the server from `model-api-service` using `bash bin/run-local`
 - Use sparsify.package based on help, if the help message is not meaningful enough, notify me and I'll update it accordingly