### PR TITLE
Add a getter for TASK_REGISTRY and DATASET_REGISTRY

### DIFF
--- a/src/sparsify/utils/constants.py
+++ b/src/sparsify/utils/constants.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Dict, Optional
 
 from sparsify.utils import TaskName
 
@@ -25,6 +26,8 @@ __all__ = [
     "TASKS",
     "TASK_REGISTRY",
     "TASKS_WITH_ALIASES",
+    "get_dataset_info",
+    "get_task_info",
 ]
 
 DEFAULT_OPTIMIZING_METRIC = "accuracy"
@@ -46,7 +49,7 @@ DEPLOYMENT_SCENARIOS = [
     DEFAULT_DEPLOYMENT_SCENARIO,
 ]
 
-TASK_REGISTRY = {
+TASK_REGISTRY: Dict[str, TaskName] = {
     "image_classification": TaskName(
         name="image_classification",
         aliases=["ic", "classification"],
@@ -88,7 +91,7 @@ TASK_REGISTRY = {
     ),
 }
 
-DATASET_REGISTRY = {
+DATASET_REGISTRY: Dict[str, TaskName] = {
     "imagenette": TASK_REGISTRY["image_classification"],
     "imagenet": TASK_REGISTRY["image_classification"],
     "coco": TASK_REGISTRY["object_detection"],
@@ -98,6 +101,31 @@ DATASET_REGISTRY = {
     "sst2": TASK_REGISTRY["text_classification"],
     "conll2003": TASK_REGISTRY["token_classification"],
 }
+
+
+def get_task_info(task_name: str) -> Optional[TaskName]:
+    """
+    :param task_name: The task name to get information for
+    :return: A TaskName object if information found else None
+    """
+    task_info: Optional[TaskName] = TASK_REGISTRY.get(task_name)
+
+    if task_info:
+        return task_info
+
+    # search in aliases
+    for name, current_task_info in TASK_REGISTRY.items():
+        if task_name == current_task_info:
+            return current_task_info
+
+
+def get_dataset_info(dataset_name: str) -> Optional[TaskName]:
+    """
+    :param dataset_name: The dataset name to get information for
+    :return: A TaskName object if information found else None
+    """
+    dataset_name = dataset_name.lower().strip().replace("-", "_")
+    return DATASET_REGISTRY.get(dataset_name)
 
 
 TASKS = list(TASK_REGISTRY.keys())

--- a/src/sparsify/utils/constants.py
+++ b/src/sparsify/utils/constants.py
@@ -103,7 +103,7 @@ DATASET_REGISTRY: Dict[str, TaskName] = {
 }
 
 
-def get_task_info(task_name: str) -> Optional[TaskName]:
+def get_task_info(task_name: Optional[str]) -> Optional[TaskName]:
     """
     :param task_name: The task name to get information for
     :return: A TaskName object if information found else None

--- a/src/sparsify/utils/constants.py
+++ b/src/sparsify/utils/constants.py
@@ -124,7 +124,7 @@ def get_dataset_info(dataset_name: str) -> Optional[TaskName]:
     :param dataset_name: The dataset name to get information for
     :return: A TaskName object if information found else None
     """
-    dataset_name = dataset_name.lower().strip().replace("-", "_")
+    dataset_name: str = dataset_name.lower().strip().replace("-", "_")
     return DATASET_REGISTRY.get(dataset_name)
 
 

--- a/src/sparsify/utils/constants.py
+++ b/src/sparsify/utils/constants.py
@@ -119,12 +119,13 @@ def get_task_info(task_name: str) -> Optional[TaskName]:
             return current_task_info
 
 
-def get_dataset_info(dataset_name: str) -> Optional[TaskName]:
+def get_dataset_info(dataset_name: Optional[str]) -> Optional[TaskName]:
     """
     :param dataset_name: The dataset name to get information for
     :return: A TaskName object if information found else None
     """
-    dataset_name: str = dataset_name.lower().strip().replace("-", "_")
+    if dataset_name:
+        dataset_name = dataset_name.lower().strip().replace("-", "_")
     return DATASET_REGISTRY.get(dataset_name)
 
 

--- a/tests/sparsify/utils/test_constants.py
+++ b/tests/sparsify/utils/test_constants.py
@@ -18,30 +18,46 @@ import pytest
 from sparsify.utils.constants import TaskName, get_dataset_info, get_task_info
 
 
+_IC_TASK = TaskName(
+    name="image_classification",
+    aliases=["ic", "classification"],
+    domain="cv",
+    sub_domain="classification",
+)
+
+_TEXT_CLASSIFICATION_TASK = TaskName(
+    name="text_classification",
+    aliases=["glue"],
+    domain="nlp",
+    sub_domain="text_classification",
+)
+
+
 @pytest.mark.parametrize(
-    "task_name",
+    "task_name, expected",
     [
-        "ic",
-        "image_Classification",
-        "classification",
-        None,
-        0,
+        ("ic", _IC_TASK),
+        ("image_Classification", _IC_TASK),
+        ("classification", _IC_TASK),
+        (None, None),
+        (0, None),
     ],
 )
-def test_get_task_info(task_name: Optional[str]):
-    task_info = get_task_info(task_name)
-    if task_name:
-        assert task_info
-        assert isinstance(task_info, TaskName)
-    else:
-        assert task_info is None
+def test_get_task_info(task_name: Optional[str], expected):
+    actual = get_task_info(task_name)
+    assert actual == expected
 
 
-@pytest.mark.parametrize("dataset_name", ["mnli", "MNLI", " mnLI ", None, 0])
-def test_get_dataset_info(dataset_name: Optional[str]):
-    dataset_info = get_dataset_info(dataset_name)
-    if dataset_name:
-        assert dataset_info
-        assert isinstance(dataset_info, TaskName)
-    else:
-        assert dataset_info is None
+@pytest.mark.parametrize(
+    "dataset_name, expected",
+    [
+        ("mnli", _TEXT_CLASSIFICATION_TASK),
+        ("MnLi", _TEXT_CLASSIFICATION_TASK),
+        (" mnlI", _TEXT_CLASSIFICATION_TASK),
+        (None, None),
+        (0, None),
+    ],
+)
+def test_get_dataset_info(dataset_name: Optional[str], expected):
+    actual = get_dataset_info(dataset_name)
+    assert actual == expected

--- a/tests/sparsify/utils/test_constants.py
+++ b/tests/sparsify/utils/test_constants.py
@@ -11,21 +11,37 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Optional
 
 import pytest
 
 from sparsify.utils.constants import TaskName, get_dataset_info, get_task_info
 
 
-@pytest.mark.parametrize("task_name", ["ic", "image_Classification", "classification"])
-def test_get_task_info(task_name: str):
+@pytest.mark.parametrize(
+    "task_name",
+    [
+        "ic",
+        "image_Classification",
+        "classification",
+        None,
+        0,
+    ],
+)
+def test_get_task_info(task_name: Optional[str]):
     task_info = get_task_info(task_name)
-    assert task_info
-    assert isinstance(task_info, TaskName)
+    if task_name:
+        assert task_info
+        assert isinstance(task_info, TaskName)
+    else:
+        assert task_info is None
 
 
-@pytest.mark.parametrize("dataset_name", ["mnli", "MNLI", " mnLI "])
-def test_get_dataset_info(dataset_name: str):
+@pytest.mark.parametrize("dataset_name", ["mnli", "MNLI", " mnLI ", None, 0])
+def test_get_dataset_info(dataset_name: Optional[str]):
     dataset_info = get_dataset_info(dataset_name)
-    assert dataset_info
-    assert isinstance(dataset_info, TaskName)
+    if dataset_name:
+        assert dataset_info
+        assert isinstance(dataset_info, TaskName)
+    else:
+        assert dataset_info is None

--- a/tests/sparsify/utils/test_constants.py
+++ b/tests/sparsify/utils/test_constants.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from sparsify.utils.constants import TaskName, get_dataset_info, get_task_info
+
+
+@pytest.mark.parametrize("task_name", ["ic", "image_Classification", "classification"])
+def test_get_task_info(task_name: str):
+    task_info = get_task_info(task_name)
+    assert task_info
+    assert isinstance(task_info, TaskName)
+
+
+@pytest.mark.parametrize("dataset_name", ["mnli", "MNLI", " mnLI "])
+def test_get_dataset_info(dataset_name: str):
+    dataset_info = get_dataset_info(dataset_name)
+    assert dataset_info
+    assert isinstance(dataset_info, TaskName)

--- a/tests/sparsify/utils/test_constants.py
+++ b/tests/sparsify/utils/test_constants.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
 
-import pytest
 
 from sparsify.utils.constants import TaskName, get_dataset_info, get_task_info
 
@@ -33,31 +31,15 @@ _TEXT_CLASSIFICATION_TASK = TaskName(
 )
 
 
-@pytest.mark.parametrize(
-    "task_name, expected",
-    [
-        ("ic", _IC_TASK),
-        ("image_Classification", _IC_TASK),
-        ("classification", _IC_TASK),
-        (None, None),
-        (0, None),
-    ],
-)
-def test_get_task_info(task_name: Optional[str], expected):
-    actual = get_task_info(task_name)
-    assert actual == expected
+def test_get_task_info():
+    assert get_task_info("ic") == _IC_TASK
+    assert get_task_info("image_Classification") == _IC_TASK
+    assert get_task_info("classification") == _IC_TASK
+    assert get_task_info(None) is None
 
 
-@pytest.mark.parametrize(
-    "dataset_name, expected",
-    [
-        ("mnli", _TEXT_CLASSIFICATION_TASK),
-        ("MnLi", _TEXT_CLASSIFICATION_TASK),
-        (" mnlI", _TEXT_CLASSIFICATION_TASK),
-        (None, None),
-        (0, None),
-    ],
-)
-def test_get_dataset_info(dataset_name: Optional[str], expected):
-    actual = get_dataset_info(dataset_name)
-    assert actual == expected
+def test_get_dataset_info():
+    assert get_dataset_info("mnli") == _TEXT_CLASSIFICATION_TASK
+    assert get_dataset_info("MnLi") == _TEXT_CLASSIFICATION_TASK
+    assert get_dataset_info("  mNli ") == _TEXT_CLASSIFICATION_TASK
+    assert get_dataset_info(None) is None


### PR DESCRIPTION
This PR adds getters for DATASET and TASK registry; making it easier to get information from registry irrespective of the case or hyphenation, +  alias matching when fetching from dict

Test plan: Automated Testing