### PR TITLE
[Auto] Add Tensorboard Support

### DIFF
--- a/src/sparsify/auto/api/api_models.py
+++ b/src/sparsify/auto/api/api_models.py
@@ -58,7 +58,7 @@ class APIArgs(BaseModel):
         default=DEFAULT_OUTPUT_DIRECTORY,
     )
     log_directory: Optional[str] = Field(
-        title="save_directory",
+        title="log_directory",
         description=(
             "Absolute path to log directory. Defaults to ./logs, relative to save "
             "directory"

--- a/src/sparsify/auto/api/api_models.py
+++ b/src/sparsify/auto/api/api_models.py
@@ -60,8 +60,7 @@ class APIArgs(BaseModel):
     log_directory: Optional[str] = Field(
         title="log_directory",
         description=(
-            "Absolute path to log directory. Defaults to ./logs, relative to save "
-            "directory"
+            "Absolute path to log directory. Defaults to <save directory>/logs"
         ),
         default=None,
     )

--- a/src/sparsify/auto/api/api_models.py
+++ b/src/sparsify/auto/api/api_models.py
@@ -57,6 +57,14 @@ class APIArgs(BaseModel):
         description="Absolute path to save directory",
         default=DEFAULT_OUTPUT_DIRECTORY,
     )
+    log_directory: Optional[str] = Field(
+        title="save_directory",
+        description=(
+            "Absolute path to log directory. Defaults to ./logging, relative to save "
+            "directory"
+        ),
+        default=None,
+    )
     performance: Union[str, float] = Field(
         title="performance",
         description=(

--- a/src/sparsify/auto/api/api_models.py
+++ b/src/sparsify/auto/api/api_models.py
@@ -60,7 +60,7 @@ class APIArgs(BaseModel):
     log_directory: Optional[str] = Field(
         title="save_directory",
         description=(
-            "Absolute path to log directory. Defaults to ./logging, relative to save "
+            "Absolute path to log directory. Defaults to ./logs, relative to save "
             "directory"
         ),
         default=None,
@@ -166,9 +166,6 @@ class SparsificationTrainingConfig(BaseModel):
     )
     base_model: str = Field(
         description="path to the model to be sparsified",
-    )
-    save_directory: str = Field(
-        description="Absolute path to save directory",
     )
     distill_teacher: Optional[str] = Field(
         description="optional path to a distillation teacher for training",

--- a/src/sparsify/auto/api/api_models.py
+++ b/src/sparsify/auto/api/api_models.py
@@ -57,14 +57,6 @@ class APIArgs(BaseModel):
         description="Absolute path to save directory",
         default=DEFAULT_OUTPUT_DIRECTORY,
     )
-    log_directory: Optional[str] = Field(
-        title="log_directory",
-        description=(
-            "Absolute path to log directory. Defaults to ./logs, relative to save "
-            "directory"
-        ),
-        default=None,
-    )
     performance: Union[str, float] = Field(
         title="performance",
         description=(

--- a/src/sparsify/auto/api/main.py
+++ b/src/sparsify/auto/api/main.py
@@ -24,6 +24,7 @@ from sparsify.auto.utils import (
     create_save_directory,
     get_trial_artifact_directory,
 )
+from tensorboard import program
 
 
 def main():
@@ -44,6 +45,12 @@ def main():
 
     # set up directory for saving
     create_save_directory(api_args)
+
+    # launch tensorboard server
+    tb = program.TensorBoard()
+    tb.configure(argv=[None, "--logdir", config.log_directory])
+    url = tb.launch()
+    print(f"TensorBoard listening on {url}")
 
     # tune until either (in order of precedence):
     # 1. number of tuning trials used up

--- a/src/sparsify/auto/api/main.py
+++ b/src/sparsify/auto/api/main.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import shutil
 import time
 from collections import OrderedDict
@@ -44,11 +45,12 @@ def main():
     training_start_time = time.time()
 
     # set up directory for saving
-    create_save_directory(api_args)
+    save_directory = create_save_directory(api_args)
 
     # launch tensorboard server
+    base_log_directory = api_args.log_directory or os.path.join(save_directory, "logs")
     tb = program.TensorBoard()
-    tb.configure(argv=[None, "--logdir", config.log_directory])
+    tb.configure(argv=[None, "--logdir", base_log_directory])
     url = tb.launch()
     print(f"TensorBoard listening on {url}")
 
@@ -65,7 +67,8 @@ def main():
         runner = TaskRunner.create(config)
 
         # Execute integration run and return metrics
-        metrics = runner.train()
+        log_directory = os.path.join(base_log_directory, f"trial_{trial_idx}")
+        metrics = runner.train(log_directory)
 
         # Move models from temporary directory to save directory, while only keeping
         # the best n models
@@ -73,7 +76,7 @@ def main():
             metrics > best_metrics for best_metrics in best_n_trial_metrics.values()
         )
         if (len(best_n_trial_metrics) < maximum_trial_saves) or is_better_than_top_n:
-            runner.move_output(trial_idx)
+            runner.move_output(target_directory=save_directory, trial_idx=trial_idx)
             best_n_trial_metrics[trial_idx] = metrics
 
         # If better trial was saved to a total of n+1 saved trials, drop worst one
@@ -97,8 +100,10 @@ def main():
 
     # Export model and create deployment folder
     best_trial_idx = max(best_n_trial_metrics, key=best_n_trial_metrics.get)
-    runner.export(best_trial_idx)
-    runner.create_deployment_directory(best_trial_idx)
+    runner.export(target_directory=save_directory, trial_idx=best_trial_idx)
+    runner.create_deployment_directory(
+        target_directory=save_directory, trial_idx=best_trial_idx
+    )
 
 
 if __name__ == "__main__":

--- a/src/sparsify/auto/api/main.py
+++ b/src/sparsify/auto/api/main.py
@@ -48,7 +48,7 @@ def main():
     save_directory = create_save_directory(api_args)
 
     # launch tensorboard server
-    base_log_directory = api_args.log_directory or os.path.join(save_directory, "logs")
+    base_log_directory = os.path.join(save_directory, "logs")
     tensorboard_server = TensorBoard()
     tensorboard_server.configure(argv=[None, "--logdir", base_log_directory])
     url = tensorboard_server.launch()

--- a/src/sparsify/auto/api/main.py
+++ b/src/sparsify/auto/api/main.py
@@ -25,7 +25,7 @@ from sparsify.auto.utils import (
     create_save_directory,
     get_trial_artifact_directory,
 )
-from tensorboard import program
+from tensorboard.program import TensorBoard
 
 
 def main():
@@ -49,9 +49,9 @@ def main():
 
     # launch tensorboard server
     base_log_directory = api_args.log_directory or os.path.join(save_directory, "logs")
-    tb = program.TensorBoard()
-    tb.configure(argv=[None, "--logdir", base_log_directory])
-    url = tb.launch()
+    tensorboard_server = TensorBoard()
+    tensorboard_server.configure(argv=[None, "--logdir", base_log_directory])
+    url = tensorboard_server.launch()
     print(f"TensorBoard listening on {url}")
 
     # tune until either (in order of precedence):

--- a/src/sparsify/auto/tasks/image_classification/runner.py
+++ b/src/sparsify/auto/tasks/image_classification/runner.py
@@ -69,10 +69,10 @@ class ImageClassificationRunner(TaskRunner):
         """
         Create sparseml integration args from SparsificationTrainingConfig. Returns
         a tuple of run args in the order (train_args, export_arts)
-
         :param config: training config to generate run for
         :return: tuple of training and export arguments
         """
+
         # create train args
         if "dataset" not in config.kwargs:
             # custom datasets are set to imagefolder
@@ -84,9 +84,6 @@ class ImageClassificationRunner(TaskRunner):
             checkpoint_path=config.base_model,
             recipe_path=config.recipe,
             recipe_args=json.dumps(config.recipe_args),
-            logs_dir=os.path.join(
-                config.save_directory, config.kwargs["model_tag"], "tensorboard_logs"
-            ),
             **config.kwargs,
         )
 
@@ -126,10 +123,11 @@ class ImageClassificationRunner(TaskRunner):
         Update run directories to save to the temporary run directory
         """
         self.train_args.save_dir = os.path.join(
-            self._run_directory.name, self.train_args.save_dir
+            self.run_directory.name, self.train_args.save_dir
         )
+        self.train_args.logs_dir = self.log_directory
         self.export_args.checkpoint_path = os.path.join(
-            self._run_directory.name, self.export_args.checkpoint_path
+            self.run_directory.name, self.export_args.checkpoint_path
         )
         self.export_args.save_dir = self.train_args.save_dir
 

--- a/src/sparsify/auto/tasks/image_classification/runner.py
+++ b/src/sparsify/auto/tasks/image_classification/runner.py
@@ -58,8 +58,9 @@ class ImageClassificationRunner(TaskRunner):
 
     def __init__(self, config: SparsificationTrainingConfig):
         super().__init__(config)
-        self._model_save_name = (
-            "model-one-shot.pth" if self.train_args.one_shot else "model.pth"
+        self._model_save_name = os.path.join(
+            "training",
+            ("model-one-shot.pth" if self.train_args.one_shot else "model.pth"),
         )
 
     @classmethod

--- a/src/sparsify/auto/tasks/object_detection/yolov5/args.py
+++ b/src/sparsify/auto/tasks/object_detection/yolov5/args.py
@@ -101,6 +101,9 @@ class _Yolov5BaseTrainArgs(BaseArgs):
     disable_ema: bool = Field(
         default=False, description="Disable EMA model updates (enabled by default)"
     )
+    log_directory: Optional[str] = Field(
+        default=None, description="Directory to log to. Defaults to save directory"
+    )
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
+++ b/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
@@ -86,7 +86,10 @@ class Yolov5Runner(TaskRunner):
         :return: tuple of training and export arguments
         """
         train_args = Yolov5TrainArgs(
-            weights=config.base_model, data=config.dataset, **config.kwargs
+            weights=config.base_model,
+            data=config.dataset,
+            log_directory=config.log_directory,
+            **config.kwargs,
         )
 
         # Determine the imminent train output directory

--- a/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
+++ b/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
@@ -88,7 +88,6 @@ class Yolov5Runner(TaskRunner):
         train_args = Yolov5TrainArgs(
             weights=config.base_model,
             data=config.dataset,
-            log_directory=config.log_directory,
             **config.kwargs,
         )
 
@@ -106,16 +105,22 @@ class Yolov5Runner(TaskRunner):
             experiment_number = int(last_experiment.group()) if last_experiment else 2
 
         # construct path to imminent run directory and weights path
-        experiment_dir = (
-            os.path.join(train_args.project, f"exp{experiment_number}")
-            if experiment_number > 1
-            else os.path.join(train_args.project, "exp")
+        relative_experiment_dir = (
+            f"exp{experiment_number}" if experiment_number > 1 else "exp"
+        )
+        absolute_experiment_dir = os.path.join(
+            train_args.project, relative_experiment_dir
+        )
+
+        # update log directory to maintain same subdirectory structure as runs
+        train_args.log_directory = os.path.join(
+            config.log_directory, relative_experiment_dir
         )
 
         # Default export args
         export_args = Yolov5ExportArgs(
             weights=os.path.join(
-                experiment_dir,
+                absolute_experiment_dir,
                 "weights",
                 "checkpoint-one-shot.pt" if train_args.one_shot else "last.pt",
             ),

--- a/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
+++ b/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
@@ -81,7 +81,6 @@ class Yolov5Runner(TaskRunner):
         """
         Create sparseml integration args from SparsificationTrainingConfig. Returns
         a tuple of run args in the order (train_args, export_arts)
-
         :param config: training config to generate run for
         :return: tuple of training and export arguments
         """
@@ -112,11 +111,6 @@ class Yolov5Runner(TaskRunner):
             train_args.project, relative_experiment_dir
         )
 
-        # update log directory to maintain same subdirectory structure as runs
-        train_args.log_directory = os.path.join(
-            config.log_directory, relative_experiment_dir
-        )
-
         # Default export args
         export_args = Yolov5ExportArgs(
             weights=os.path.join(
@@ -141,10 +135,11 @@ class Yolov5Runner(TaskRunner):
         Update run directories to save to the temporary run directory
         """
         self.train_args.project = os.path.join(
-            self._run_directory.name, self.train_args.project
+            self.run_directory.name, self.train_args.project
         )
+        self.train_args.log_directory = self.log_directory
         self.export_args.weights = os.path.join(
-            self._run_directory.name, self.export_args.weights
+            self.run_directory.name, self.export_args.weights
         )
 
     def memory_stepdown(self):
@@ -228,7 +223,7 @@ class Yolov5Runner(TaskRunner):
         Retrieve metrics from training output.
         """
         results = pandas.read_csv(
-            os.path.join(Path(self.export_args.weights).parents[1], "results.csv"),
+            os.path.join(self.log_directory, "results.csv"),
             skipinitialspace=True,
         )
         return Metrics(

--- a/src/sparsify/auto/tasks/transformers/runner.py
+++ b/src/sparsify/auto/tasks/transformers/runner.py
@@ -64,7 +64,6 @@ class _TransformersRunner(TaskRunner):
         """
         Create sparseml integration args from SparsificationTrainingConfig. Returns
         a tuple of run args in the order (train_args, export_arts)
-
         :param config: training config to generate run for
         :return: tuple of training and export arguments
         """
@@ -91,8 +90,9 @@ class _TransformersRunner(TaskRunner):
         Update run directories to save to the temporary run directory
         """
         self.train_args.output_dir = os.path.join(
-            self._run_directory.name, self.train_args.output_dir
+            self.run_directory.name, self.train_args.output_dir
         )
+        self.train_args.logging_dir - self.log_directory
         self.export_args.model_path = self.train_args.output_dir
 
     def memory_stepdown(self):
@@ -144,7 +144,7 @@ class _TransformersRunner(TaskRunner):
         Checks if export run completed successfully
         """
 
-        onnx_file = os.path.join(self._run_directory.name, "deployment", "model.onnx")
+        onnx_file = os.path.join(self.run_directory.name, "deployment", "model.onnx")
 
         # Check mode file exists
         if not os.path.isfile(onnx_file):

--- a/src/sparsify/auto/tasks/transformers/runner.py
+++ b/src/sparsify/auto/tasks/transformers/runner.py
@@ -71,6 +71,7 @@ class _TransformersRunner(TaskRunner):
         train_args = cls.train_args_class(
             model_name_or_path=config.base_model,
             dataset_name=config.dataset,
+            logging_dir=
             **config.kwargs,
         )
 

--- a/src/sparsify/auto/tasks/transformers/runner.py
+++ b/src/sparsify/auto/tasks/transformers/runner.py
@@ -71,7 +71,6 @@ class _TransformersRunner(TaskRunner):
         train_args = cls.train_args_class(
             model_name_or_path=config.base_model,
             dataset_name=config.dataset,
-            logging_dir=
             **config.kwargs,
         )
 

--- a/src/sparsify/auto/utils/helpers.py
+++ b/src/sparsify/auto/utils/helpers.py
@@ -26,7 +26,7 @@ __all__ = ["SAVE_DIR", "create_save_directory", "get_trial_artifact_directory"]
 SAVE_DIR = "auto_{{task}}{:_%Y_%m_%d_%H_%M_%S}".format(datetime.now())
 
 
-def create_save_directory(api_args: APIArgs):
+def create_save_directory(api_args: APIArgs) -> str:
     """
     Create base save directory structure for a single sparsify.auto run
 
@@ -37,6 +37,8 @@ def create_save_directory(api_args: APIArgs):
     os.makedirs(save_directory, exist_ok=True)
     os.mkdir(os.path.join(save_directory, "run_artifacts"))
     os.mkdir(os.path.join(save_directory, "logs"))
+
+    return save_directory
 
 
 def get_trial_artifact_directory(api_args: APIArgs, trial_idx: int) -> str:

--- a/tests/sparsify/auto/autosparse/test_main.py
+++ b/tests/sparsify/auto/autosparse/test_main.py
@@ -66,7 +66,7 @@ def _train_side_effect_mock(self):
     os.mkdir(os.path.join(train_artifact_path, "artifact_subdirectory"))
 
 
-def _export_side_effect_mock(self, trial_idx):
+def _export_side_effect_mock(self, target_directory, trial_idx):
     _test_trial_artifact_directory(trial_idx)
     deployment_path = os.path.join(
         _TRIAL_PATH.format(trial_idx=trial_idx), "deployment"


### PR DESCRIPTION
This PR add Tensorboard support to `sparsify.auto` by:
- Spinning up a tensorboard server with a train route
- Routing logs to the `./logs` directory, relative to the save directory by default
- Allowing for user override of logging directory with optional `log_directory` cli arg

