### PR TITLE
Only try to install pysqlite-binary on x86_64 linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import os
-from sys import platform
+import platform
+from sys import platform as sys_platform
 from typing import Dict, List, Tuple
 
 from setuptools import find_packages, setup
@@ -65,7 +66,9 @@ _dev_deps = [
     "wheel>=0.36.2",
 ]
 
-if platform == "linux" or platform == "linux2":
+if platform.processor() == "x86_64" and (
+    sys_platform == "linux" or sys_platform == "linux2"
+):
     _deps.extend(["pysqlite3-binary>=0.4.0"])
 
 


### PR DESCRIPTION
Can't tell how needed this dependency really is, but `pysqlite-binary` only builds binaries for `x86_64` so we shouldn't try to install it for other chip architectures.

![Screen Shot 2022-11-03 at 8 14 44 AM](https://user-images.githubusercontent.com/2316989/199718308-3eb24438-f163-4fe3-ab8a-2078eaa7adf6.png)

With this change in place I'm able to successfully run `pip install .` on my Ubuntu+M1 setup, which was my goal.
