### PR TITLE
[Auto] Support for multi-stage tuning

### DIFF
--- a/src/sparsify/auto/api/api_models.py
+++ b/src/sparsify/auto/api/api_models.py
@@ -164,7 +164,7 @@ class APIArgs(BaseModel):
     )
     teacher_only: bool = Field(
         title="teacher_only",
-        description=("set to True to only auto train the teacher"),
+        description=("set to True to only auto tune the teacher"),
         default=False,
     )
 

--- a/src/sparsify/auto/api/api_models.py
+++ b/src/sparsify/auto/api/api_models.py
@@ -58,14 +58,6 @@ class APIArgs(BaseModel):
         description="Absolute path to save directory",
         default=DEFAULT_OUTPUT_DIRECTORY,
     )
-    log_directory: Optional[str] = Field(
-        title="log_directory",
-        description=(
-            "Absolute path to log directory. Defaults to ./logs, relative to save "
-            "directory"
-        ),
-        default=None,
-    )
     performance: Union[str, float] = Field(
         title="performance",
         description=(
@@ -91,10 +83,12 @@ class APIArgs(BaseModel):
         description="keyword args to override recipe variables with",
         default_factory=dict,
     )
-    distill_teacher: Optional[str] = Field(
+    distill_teacher: str = Field(
         title="distil_teacher",
-        description="optional path to a distillation teacher model for training",
-        default=None,
+        description="teacher to use for distillation. Can be a path to a model file or "
+        "zoo stub, 'off' for no distillation, and default value of 'auto' to auto-tune "
+        "base model as teacher",
+        default="auto",
     )
     num_trials: Optional[int] = Field(
         title="num_trials",
@@ -133,9 +127,8 @@ class APIArgs(BaseModel):
     resume: Optional[str] = Field(
         title="resume",
         description=(
-            "To continue a tuning run, provide path to trial history YAML file or path "
-            "to run output directory containing the 'trial_history.yaml' file. "
-            "Turned off by default"
+            "To continue a tuning run, provide path to the high level directory of run "
+            "you wish to resume"
         ),
         default=None,
     )
@@ -151,6 +144,28 @@ class APIArgs(BaseModel):
         title="kwargs",
         description="optional task specific arguments to add to config",
         default_factory=dict,
+    )
+    teacher_kwargs: Optional[Dict[str, Any]] = Field(
+        title="teacher_kwargs",
+        description="optional task specific arguments to add to teacher config",
+        default_factory=dict,
+    )
+    tuning_parameters: Optional[str] = Field(
+        title="tuning_parameters",
+        description="path to config file containing custom parameter tuning settings. "
+        "See example tuning config output for expected format",
+        default=None,
+    )
+    teacher_tuning_parameters: Optional[str] = Field(
+        title="teacher_tuning_parameters",
+        description="path to config file containing custom teacher parameter tuning "
+        "settings. See example tuning config output for expected format",
+        default=None,
+    )
+    teacher_only: bool = Field(
+        title="teacher_only",
+        description=("set to True to only auto train the teacher"),
+        default=False,
     )
 
     @validator("task")
@@ -193,9 +208,9 @@ class SparsificationTrainingConfig(BaseModel):
     base_model: str = Field(
         description="path to the model to be sparsified",
     )
-    distill_teacher: Optional[str] = Field(
+    distill_teacher: str = Field(
         description="optional path to a distillation teacher for training",
-        default=None,
+        default="auto",
     )
     recipe: str = Field(
         description="file path to or zoo stub of sparsification recipe to be applied",

--- a/src/sparsify/auto/api/api_models.py
+++ b/src/sparsify/auto/api/api_models.py
@@ -27,7 +27,7 @@ import yaml
 
 from pydantic import BaseModel, Field, validator
 from sparsify.auto.utils import SampledHyperparameter
-from sparsify.utils import TASK_REGISTRY
+from sparsify.utils import DEFAULT_OPTIMIZING_METRIC, METRICS, TASK_REGISTRY
 
 
 __all__ = [
@@ -130,6 +130,23 @@ class APIArgs(BaseModel):
         ),
         default=False,
     )
+    resume: Optional[str] = Field(
+        title="resume",
+        description=(
+            "To continue a tuning run, provide path to trial history YAML file or path "
+            "to run output directory containing the 'trial_history.yaml' file. "
+            "Turned off by default"
+        ),
+        default=None,
+    )
+    optimizing_metric: str = Field(
+        title="optimizing_metric",
+        description=(
+            "The criterion to search model for, multiple metrics can be specified as"
+            f"comma separated values, supported metrics are {METRICS}"
+        ),
+        default=DEFAULT_OPTIMIZING_METRIC,
+    )
     kwargs: Optional[Dict[str, Any]] = Field(
         title="kwargs",
         description="optional task specific arguments to add to config",
@@ -199,13 +216,13 @@ class SparsificationTrainingConfig(BaseModel):
         ),
         default=[],
     )
-    optimizing_metrics: List[str] = Field(
-        title="optimizing_metrics",
+    optimizing_metric: str = Field(
+        title="optimizing_metric",
         description=(
-            "List of metrics to optimize for during hyperparameter tuning. Each "
-            "element must match name of field in Metrics class"
+            "The criterion to search model for, multiple metrics can be specified as"
+            f"comma separated values, supported metrics are {METRICS}"
         ),
-        default=["accuracy"],
+        default=DEFAULT_OPTIMIZING_METRIC,
     )
     no_stopping: bool = Field(
         title="no_stopping",

--- a/src/sparsify/auto/api/main.py
+++ b/src/sparsify/auto/api/main.py
@@ -15,14 +15,16 @@
 import os
 import shutil
 import time
+import warnings
 from collections import OrderedDict
 from typing import Dict, List, Tuple
 
-from sparsify.auto.api.api_models import APIArgs, SparsificationTrainingConfig
+from sparsify.auto.api.api_models import APIArgs, Metrics, SparsificationTrainingConfig
 from sparsify.auto.tasks import TaskRunner
 from sparsify.auto.utils import (
     api_request_config,
     api_request_tune,
+    best_n_trials_from_history,
     create_save_directory,
     get_trial_artifact_directory,
     load_raw_config_history,

--- a/src/sparsify/auto/api/main.py
+++ b/src/sparsify/auto/api/main.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import time
 from collections import OrderedDict
+from typing import Dict, List, Tuple
 
 from sparsify.auto.api.api_models import APIArgs, SparsificationTrainingConfig
 from sparsify.auto.tasks import TaskRunner
@@ -24,51 +25,232 @@ from sparsify.auto.utils import (
     api_request_tune,
     create_save_directory,
     get_trial_artifact_directory,
+    load_raw_config_history,
+    request_student_teacher_configs,
+    save_history,
 )
 from tensorboard.program import TensorBoard
 
 
 def main():
+    # Tuning tracking variables
+    history = {"teacher": [], "student": []}
+    best_n_trial_metrics = {
+        "teacher": OrderedDict(),
+        "student": OrderedDict(),
+    }  # map trail_idx to metrics
+    start_idx = 0
+    resume_stage = None
+
     # Parse CLI args
     api_args = APIArgs.from_cli()
-    max_train_seconds = api_args.max_train_time * 60 * 60
-    max_tune_trials = api_args.num_trials or float("inf")
-    maximum_trial_saves = api_args.maximum_trial_saves or float("inf")
 
-    # setup run loop variables
-    history = []
-    best_n_trial_metrics = OrderedDict()  # map trail_idx to metrics
-    trial_idx = 0
+    # Load state from previous run
+    if api_args.resume:
+        # Load history from YAML file
+        raw_history = load_raw_config_history(api_args.resume)
 
-    # request initial training config
-    config = SparsificationTrainingConfig(**api_request_config(api_args))
-    training_start_time = time.time()
+        # API args to be loaded from history file, all CLI args passed on this call
+        # to be ignored
+        resume_directory = api_args.resume
+        api_args = APIArgs(**raw_history["api_args"])
+        api_args.resume = resume_directory
 
-    # set up directory for saving
-    save_directory = create_save_directory(api_args)
+        # Reconstruct run history
+        history["teacher"] = [
+            (
+                SparsificationTrainingConfig(**trial["config"]),
+                Metrics(**trial["metrics"]),
+            )
+            for trial in raw_history["teacher"].values()
+        ]
 
-    # launch tensorboard server
-    base_log_directory = os.path.join(save_directory, "logs")
+        history["student"] = [
+            (
+                SparsificationTrainingConfig(**trial["config"]),
+                Metrics(**trial["metrics"]),
+            )
+            for trial in raw_history["student"].values()
+        ]
+
+        best_n_trial_metrics["teacher"] = best_n_trials_from_history(
+            history["teacher"], api_args.maximum_trial_saves
+        )
+        best_n_trial_metrics["student"] = best_n_trials_from_history(
+            history["student"], api_args.maximum_trial_saves
+        )
+        start_idx = len(history)
+
+        # Only teacher and student stages supported at this time
+        resume_stage = (
+            "student"
+            if (
+                len(history["student"]) > 0
+                or len(history["teacher"]) == api_args.num_trials
+            )
+            else "teacher"
+        )
+
+        # Check whether the run can continue to be tuned
+        config_dict = api_request_tune(history[resume_stage])
+        if config_dict.get("tuning_complete"):
+            if resume_stage == "student":
+                raise ValueError(
+                    "Tuning stop condition already satisfied for provided run. To turn "
+                    "off stopping condition use the `--no_stopping` flag"
+                )
+            else:
+                warnings.warn(
+                    "Tuning stop condition already satisfied for teacher "
+                    "stage. Skipping to training student. To turn off stopping  "
+                    "condition use the `--no_stopping` flag"
+                )
+
+        student_config, teacher_config = None, None
+        if resume_stage == "student":
+            student_config = SparsificationTrainingConfig(**config_dict)
+        else:
+            teacher_config = SparsificationTrainingConfig(**config_dict)
+            if not api_args.teacher_only:
+                student_config = api_request_config(api_args)
+
+        save_directory = api_args.resume
+        base_log_directory = os.path.join(save_directory, "training", "logs")
+        base_artifact_directory = os.path.join(
+            save_directory, "training", "run_artifacts"
+        )
+
+    else:
+        # Request initial training configs
+        student_config, teacher_config = request_student_teacher_configs(api_args)
+
+        # Set up directory for saving
+        (
+            save_directory,
+            base_artifact_directory,
+            base_log_directory,
+        ) = create_save_directory(api_args)
+
+    # Launch tensorboard server
     tensorboard_server = TensorBoard()
     tensorboard_server.configure(argv=[None, "--logdir", base_log_directory])
     url = tensorboard_server.launch()
     print(f"TensorBoard listening on {url}")
+
+    max_tune_trials = api_args.num_trials or float("inf")
+    tuning_start_time = time.time()
+
+    # Train teacher
+    if teacher_config:
+        teacher_artifact_directory = os.path.join(base_artifact_directory, "teacher")
+        teacher_log_directory = os.path.join(base_log_directory, "teacher")
+
+        teacher_runner = _train(
+            config=teacher_config,
+            api_args=api_args,
+            history=history["teacher"],
+            best_n_trial_metrics=best_n_trial_metrics["teacher"],
+            start_idx=start_idx,
+            max_tune_trials=max_tune_trials,
+            tuning_start_time=tuning_start_time,
+            artifact_directory=teacher_artifact_directory,
+            log_directory=teacher_log_directory,
+            stage="teacher",
+        )
+
+        # Determine the best teacher trained and assign to student
+        best_trial_idx = max(
+            best_n_trial_metrics["teacher"], key=best_n_trial_metrics.get
+        )
+        best_trial_path = get_trial_artifact_directory(
+            teacher_artifact_directory, best_trial_idx
+        )
+        best_teacher_path = os.path.join(
+            best_trial_path, teacher_runner.model_save_name
+        )
+
+        if student_config:
+            student_config.distill_teacher = best_teacher_path
+
+    # Train student
+    if student_config:
+        student_artifact_directory = os.path.join(base_artifact_directory, "student")
+        student_log_directory = os.path.join(base_log_directory, "student")
+
+        student_runner = _train(
+            config=student_config,
+            api_args=api_args,
+            history=history["student"],
+            best_n_trial_metrics=best_n_trial_metrics["student"],
+            start_idx=start_idx
+            if not (api_args.resume and resume_stage == "teacher")
+            else 0,
+            max_tune_trials=max_tune_trials,
+            tuning_start_time=tuning_start_time,
+            artifact_directory=student_artifact_directory,
+            log_directory=student_log_directory,
+            stage="student",
+        )
+
+        # Export student and create deployment directory
+        best_trial_idx = max(
+            best_n_trial_metrics["student"], key=best_n_trial_metrics["student"].get
+        )
+        trial_artifact_directory = get_trial_artifact_directory(
+            student_artifact_directory, best_trial_idx
+        )
+        student_runner.export(model_directory=trial_artifact_directory)
+        student_runner.create_deployment_directory(
+            target_directory=save_directory, trial_idx=best_trial_idx
+        )
+
+
+def _train(
+    config: SparsificationTrainingConfig,
+    api_args: APIArgs,
+    history: List[Tuple[SparsificationTrainingConfig, Metrics]],
+    best_n_trial_metrics: Dict[int, Metrics],
+    start_idx: int,
+    max_tune_trials: int,
+    tuning_start_time: float,
+    artifact_directory: str,
+    log_directory: str,
+    stage: str,
+):
+    """
+    Perform hyperparamter tuning by training multiple iterations of the model
+
+    :param config: config to define the initial training running
+    :param api_args: user defined settings
+    :param history: history of runs attempted so far in this experiment. Empty unless
+        the --resume flag was used
+    :param best_n_trial_metrics: mapping of trail_idx to metrics for at most n runs with
+        the best metrics. Empty unless the --resume flag was used
+    :param start_idx: trial number to start on. 0 unless the --resume flag was used
+    :param max_tune_trials: maximum number of tuning trials to run
+    :param tuning_start_time: time at which auto parameter tuning started
+    :param artifact_directory: path to the artifacts directory for this stage
+    :param log directory: path to the logging directory for this stage
+    :param stage: name of stage, used for saving to the run history file
+    """
+    maximum_trial_saves = api_args.maximum_trial_saves or float("inf")
+    trial_idx = start_idx
 
     # tune until either (in order of precedence):
     # 1. number of tuning trials used up
     # 2. maximum tuning time exceeded
     # 3. tuning early stopping condition met
     while (
-        len(history) < max_tune_trials
-        and time.time() - training_start_time <= max_train_seconds
+        trial_idx < start_idx + max_tune_trials
+        and time.time() - tuning_start_time <= api_args.max_train_time * 60 * 60
     ):
 
         # Create a runner from the config, based on the task specified by config.task
         runner = TaskRunner.create(config)
 
         # Execute integration run and return metrics
-        log_directory = os.path.join(base_log_directory, f"trial_{trial_idx}")
         metrics = runner.train(log_directory)
+        log_directory = os.path.join(log_directory, f"trial_{trial_idx}")
 
         # Move models from temporary directory to save directory, while only keeping
         # the best n models
@@ -76,17 +258,25 @@ def main():
             metrics > best_metrics for best_metrics in best_n_trial_metrics.values()
         )
         if (len(best_n_trial_metrics) < maximum_trial_saves) or is_better_than_top_n:
-            runner.move_output(target_directory=save_directory, trial_idx=trial_idx)
+            runner.move_output(target_directory=artifact_directory, trial_idx=trial_idx)
             best_n_trial_metrics[trial_idx] = metrics
 
         # If better trial was saved to a total of n+1 saved trials, drop worst one
         if len(best_n_trial_metrics) > maximum_trial_saves:
             drop_trial_idx = min(best_n_trial_metrics, key=best_n_trial_metrics.get)
-            shutil.rmtree(get_trial_artifact_directory(api_args, drop_trial_idx))
+            shutil.rmtree(
+                get_trial_artifact_directory(artifact_directory, drop_trial_idx)
+            )
             del best_n_trial_metrics[drop_trial_idx]
 
         # save run history as list of pairs of (config, metrics)
         history.append((config, metrics))
+        save_history(
+            history=history,
+            api_args=api_args,
+            stage=stage,
+            target_directory=artifact_directory,
+        )
 
         # request a config with a new set of hyperparameters
         config_dict = api_request_tune(history)
@@ -98,12 +288,7 @@ def main():
 
         trial_idx += 1
 
-    # Export model and create deployment folder
-    best_trial_idx = max(best_n_trial_metrics, key=best_n_trial_metrics.get)
-    runner.export(target_directory=save_directory, trial_idx=best_trial_idx)
-    runner.create_deployment_directory(
-        target_directory=save_directory, trial_idx=best_trial_idx
-    )
+    return runner
 
 
 if __name__ == "__main__":

--- a/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
+++ b/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
@@ -227,7 +227,7 @@ class Yolov5Runner(TaskRunner):
             skipinitialspace=True,
         )
         return Metrics(
-            accuracy={
+            metrics={
                 key.split("/")[1]: float(results[key].iloc[-1])
                 for key in _ACCURACY_KEYS
             },

--- a/src/sparsify/auto/tasks/transformers/args.py
+++ b/src/sparsify/auto/tasks/transformers/args.py
@@ -95,18 +95,6 @@ class _TransformersTrainArgs(BaseArgs):
         default=None,
         description=("A csv or a json file containing the test data."),
     )
-    text_column_name: Optional[str] = Field(
-        default=None,
-        description=(
-            "The column name of text to input in the file " "(a csv or JSON file)."
-        ),
-    )
-    label_column_name: Optional[str] = Field(
-        default=None,
-        description=(
-            "The column name of label to input in the file " "(a csv or JSON file)."
-        ),
-    )
     overwrite_cache: bool = Field(
         default=False,
         description=("Overwrite the cached training and evaluation sets"),
@@ -520,13 +508,6 @@ class _TransformersTrainArgs(BaseArgs):
         description="Used by the SageMaker launcher to send mp-specific args. "
         "Ignored in Trainer",
     )
-    modifier_log_frequency: float = Field(
-        default=0.1,
-        description=(
-            "How often to log SparseML modifier data, in number of epochs or fraction "
-            "of epochs"
-        ),
-    )
 
 
 class QuestionAnsweringArgs(_TransformersTrainArgs):
@@ -588,6 +569,18 @@ class TextClassificationArgs(_TransformersTrainArgs):
             "The name of the task to train on: " + ", ".join(_TASK_TO_KEYS.keys())
         ),
     )
+    text_column_name: Optional[str] = Field(
+        default=None,
+        description=(
+            "The column name of text to input in the file " "(a csv or JSON file)."
+        ),
+    )
+    label_column_name: Optional[str] = Field(
+        default=None,
+        description=(
+            "The column name of label to input in the file " "(a csv or JSON file)."
+        ),
+    )
 
 
 class TokenClassificationArgs(_TransformersTrainArgs):
@@ -615,6 +608,18 @@ class TokenClassificationArgs(_TransformersTrainArgs):
     )
     task_name: Optional[str] = Field(
         default="ner", description=("The name of the task (ner, pos...).")
+    )
+    text_column_name: Optional[str] = Field(
+        default=None,
+        description=(
+            "The column name of text to input in the file " "(a csv or JSON file)."
+        ),
+    )
+    label_column_name: Optional[str] = Field(
+        default=None,
+        description=(
+            "The column name of label to input in the file " "(a csv or JSON file)."
+        ),
     )
 
 

--- a/src/sparsify/auto/tasks/transformers/runner.py
+++ b/src/sparsify/auto/tasks/transformers/runner.py
@@ -70,6 +70,9 @@ class _TransformersRunner(TaskRunner):
         train_args = cls.train_args_class(
             model_name_or_path=config.base_model,
             dataset_name=config.dataset,
+            distill_teacher=config.distill_teacher
+            if not config.distill_teacher == "off"
+            else None,
             **config.kwargs,
         )
 
@@ -92,7 +95,7 @@ class _TransformersRunner(TaskRunner):
         self.train_args.output_dir = os.path.join(
             self.run_directory.name, self.train_args.output_dir
         )
-        self.train_args.logging_dir - self.log_directory
+        self.train_args.logging_dir = self.log_directory
         self.export_args.model_path = self.train_args.output_dir
 
     def memory_stepdown(self):

--- a/src/sparsify/auto/utils/helpers.py
+++ b/src/sparsify/auto/utils/helpers.py
@@ -17,14 +17,23 @@ Generic helpers for sparsify.auto
 """
 import os
 from datetime import datetime
+from typing import Any, Dict, List, Tuple, Union
 
 
-__all__ = ["SAVE_DIR", "create_save_directory", "get_trial_artifact_directory"]
+
+__all__ = [
+    "SAVE_DIR",
+    "create_save_directory",
+    "get_trial_artifact_directory",
+    "save_history",
+    "load_raw_config_history",
+    "best_n_trials_from_history",
+]
 
 SAVE_DIR = "auto_{{task}}{:_%Y_%m_%d_%H_%M_%S}".format(datetime.now())
 
 
-def create_save_directory(api_args: "APIArgs") -> str:  # noqa: F821
+def create_save_directory(api_args: "APIArgs") -> Tuple[str]:  # noqa: F821
     """
     Create base save directory structure for a single sparsify.auto run
 
@@ -32,22 +41,90 @@ def create_save_directory(api_args: "APIArgs") -> str:  # noqa: F821
     save_directory = os.path.join(
         api_args.save_directory, SAVE_DIR.format(task=api_args.task)
     )
+    log_directory = os.path.join(save_directory, "training", "logs")
+    artifact_directory = os.path.join(save_directory, "training", "run_artifacts")
     os.makedirs(save_directory, exist_ok=True)
-    os.mkdir(os.path.join(save_directory, "run_artifacts"))
-    os.mkdir(os.path.join(save_directory, "logs"))
+    os.makedirs(log_directory)
+    os.makedirs(artifact_directory)
 
-    return save_directory
+    return save_directory, artifact_directory, log_directory
 
 
-def get_trial_artifact_directory(
-    api_args: "APIArgs", trial_idx: int  # noqa: F821
-) -> str:
+def save_history(
+    history: List[Tuple["SparsificationTrainingConfig", "Metrics"]],  # noqa: F821
+    api_args: "APIArgs",  # noqa: F821
+    stage: str,
+    target_directory: str,
+):
     """
-    Return the path to a trial's save directory
+    Saves the stage and run history files, where trial history refers to the history of
+    one stage and run history refers to the history of all stages
     """
-    return os.path.join(
-        api_args.save_directory,
-        SAVE_DIR.format(task=api_args.task),
-        "run_artifacts",
-        f"trial_{trial_idx}",
+    trial_history_dict = {
+        f"trial_{idx}": {"config": config.dict(), "metrics": metrics.dict()}
+        for idx, (config, metrics) in enumerate(history)
+    }
+
+    # Save stage history
+    with open(os.path.join(target_directory, "stage_history.yaml"), "w") as file:
+        yaml.safe_dump(
+            {**{"api_args": api_args.dict()}, **trial_history_dict},
+            file,
+        )
+
+    # Update run history file
+    filepath = os.path.join(os.path.dirname(target_directory), "run_history.yaml")
+    if os.path.exists(filepath):
+        with open(filepath, "r") as file:
+            run_history = yaml.safe_load(file)
+            run_history[stage] = trial_history_dict
+    else:
+        run_history = {
+            **{"api_args": api_args.dict()},
+            **{stage: trial_history_dict},
+        }
+
+    with open(filepath, "w") as file:
+        yaml.safe_dump(run_history, file)
+
+
+def load_raw_config_history(path: str) -> Dict[str, Any]:
+    """
+    Loads a raw dict of the run history from the specified run save path, within
+    which `run_history.yaml` will be found and loaded
+    """
+    path = (
+        path
+        if os.path.isfile(path)
+        else os.path.join(path, "training", "run_artifacts", "run_history.yaml")
     )
+    if not os.path.exists(path):
+        raise ValueError(f"Run history file {path} not found")
+
+    with open(path, "r") as stream:
+        return yaml.safe_load(stream)
+
+
+def best_n_trials_from_history(
+    history: List[Tuple["SparsificationTrainingConfig", "Metrics"]],  # noqa: F821
+    n: Union[int, float],
+):
+    """
+    Get the top n best trials by metrics from the run history
+
+    :param history: run history
+    :param n: number of top trials to extract. Value of inf can be passed to extract all
+    the trials
+    """
+    n = n if n != float("inf") else len(history)
+    ordered_trials = sorted(history, key=lambda x: x[1])
+    return OrderedDict(
+        [(idx, metrics) for idx, (_, metrics) in enumerate(ordered_trials[:n])]
+    )
+
+
+def get_trial_artifact_directory(artifact_directory: str, trial_idx: int) -> str:
+    """
+    Return the path to the trial from the artifact directory
+    """
+    return os.path.join(artifact_directory, f"trial_{trial_idx}")

--- a/src/sparsify/auto/utils/helpers.py
+++ b/src/sparsify/auto/utils/helpers.py
@@ -16,9 +16,11 @@
 Generic helpers for sparsify.auto
 """
 import os
+from collections import OrderedDict
 from datetime import datetime
 from typing import Any, Dict, List, Tuple, Union
 
+import yaml
 
 
 __all__ = [

--- a/src/sparsify/auto/utils/nm_api.py
+++ b/src/sparsify/auto/utils/nm_api.py
@@ -23,7 +23,7 @@ from sparsify.auto.api.api_models import APIArgs, Metrics, SparsificationTrainin
 from sparsify.utils import get_base_url
 
 
-__all__ = ["api_request_config", "api_request_tune"]
+__all__ = ["api_request_config", "api_request_tune", "request_student_teacher_configs"]
 
 _CONFIG_REQUEST_END_POINT = "/v1/sparsify/auto/training-config"
 _CONFIG_TUNE_END_POINT = "/v1/sparsify/auto/training-config/tune"
@@ -31,9 +31,9 @@ _CONFIG_TUNE_END_POINT = "/v1/sparsify/auto/training-config/tune"
 
 def api_request_config(api_args: APIArgs) -> dict:
     """
-    Make a server request for the initial training config
+    Make a server request for the initial training configs
 
-    :return: dictionary of SparsificationTrainingConfig object
+    :return: dictionary of SparsificationTrainingConfig objects
     """
     response = requests.post(
         f"{get_base_url()}{_CONFIG_REQUEST_END_POINT}",
@@ -55,3 +55,21 @@ def api_request_tune(history: Tuple[SparsificationTrainingConfig, Metrics]) -> d
     )
 
     return response.json()
+
+
+def request_student_teacher_configs(api_args: "APIArgs"):
+    student_config, teacher_config = None, None
+
+    if api_args.teacher_only:
+        teacher_config = SparsificationTrainingConfig(**api_request_config(api_args))
+
+    else:
+        student_config = SparsificationTrainingConfig(**api_request_config(api_args))
+        if api_args.distill_teacher == "auto":
+            teacher_input_args = api_args.copy(deep=True)
+            teacher_input_args.teacher_only = True
+            teacher_config = SparsificationTrainingConfig(
+                **api_request_config(teacher_input_args)
+            )
+
+    return student_config, teacher_config

--- a/src/sparsify/auto/utils/nm_api.py
+++ b/src/sparsify/auto/utils/nm_api.py
@@ -57,7 +57,13 @@ def api_request_tune(history: Tuple[SparsificationTrainingConfig, Metrics]) -> d
     return response.json()
 
 
-def request_student_teacher_configs(api_args: "APIArgs"):
+def request_student_teacher_configs(
+    api_args: APIArgs,
+) -> Tuple[SparsificationTrainingConfig, SparsificationTrainingConfig]:
+    """
+    Request student and/or teacher sparsification configs from the NM API
+    """
+
     student_config, teacher_config = None, None
 
     if api_args.teacher_only:
@@ -65,7 +71,7 @@ def request_student_teacher_configs(api_args: "APIArgs"):
 
     else:
         student_config = SparsificationTrainingConfig(**api_request_config(api_args))
-        if api_args.distill_teacher == "auto":
+        if student_config.distill_teacher == "auto":
             teacher_input_args = api_args.copy(deep=True)
             teacher_input_args.teacher_only = True
             teacher_config = SparsificationTrainingConfig(


### PR DESCRIPTION
This PR adds support for multi-stage training, where the `teacher` and `student` stages are supported. 

With multi-stages, the new run flow for sparsify.auto is:
- Automatically tune a distillation teacher, followed by the student in the nominal case, if the integration supports distillation
- Allow a user to provide their own distillation teacher and skip the teacher tuning stage
- Allow continued tuning on an existing run with `--resume`, continuing from the correct stage
- Allow the option for teacher only tuning, so a user can either:
    - Verify they're satisfied with their teacher before automatically continuing to the student stage
    - Continue tuning a teacher from a run where the student training has already started and `--resume` would continue from the run from the student

**Test Plan**
```
sparsify.auto --task question_answering --optimizing_metric latency --dataset squad --kwargs {'max_steps': 20, 'per_device_train_batch_size': 8} --teacher_kwargs {'max_steps': 10, 'per_device_train_batch_size': 8} --num_trials 1
```
```
sparsify.auto --task question_answering --resume PATH/TO/EXISTING/RUN
```
```
sparsify.auto --task object_detection --dataset coco128.yaml
```
```
sparsify.auto --task image_classification --dataset /home/ubuntu/.fastai/data/imagenette2-160
```