### PR TITLE
Update the user output for `sparsify.package`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,25 @@
+# Setup the base image
+FROM python:3.8-slim-bullseye
+
+# Install git
+RUN : \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Activate venv
+RUN python3.8 -m venv /venv
+ENV PATH="venv/bin:$PATH"
+
+RUN pip3 install --upgrade setuptools wheel
+
+# Setup DeepSparse
+
+ARG GIT_CHECKOUT
+# if $GIT_CHECKOUT is not specified - just install from pypi
+RUN if [ -z "${GIT_CHECKOUT}" ] ; then pip3 install --no-cache-dir --upgrade deepsparse[server] ; fi
+
+# if $GIT_CHECKOUT is specified - clone, checkout $GIT_CHECKOUT, and install with -e
+RUN if [ -n "${GIT_CHECKOUT}" ] ; then git clone https://github.com/neuralmagic/deepsparse.git --depth 1 -b $GIT_CHECKOUT; fi
+RUN if [ -n "${GIT_CHECKOUT}" ] ; then pip3 install --no-cache-dir --upgrade -e "./deepsparse[server]" ; fi

--- a/src/sparsify/package/cli.py
+++ b/src/sparsify/package/cli.py
@@ -124,13 +124,17 @@ def _get_template(results: Mapping[str, Any]):
     )
     deployment_path = _download_deployment_directory(stub)
     download_instructions = f"""
-        Kindly use the dockerfile in sparsify/docker/Dockerfile to build deepsparse
-        image and run the container. Run the following command inside `sparsify/Docker`
-        directory:
-                
-        docker build -t deepsparse_docker . && docker run -it deepsparse_docker \\
-         deepsparse.server --task <TASK-NAME> --model_path {deployment_path}
+        Use the dockerfile in sparsify/docker/Dockerfile to build deepsparse
+        image and run the `deepsparse.server` container. 
         
+        Run the following command inside `sparsify/Docker`
+        directory (Note: replace <TASK-NAME> with appropriate task):
+        
+        ```bash        
+        docker build -t deepsparse_docker . && docker run -it \\
+        -v {deployment_path}:/home/deployment  deepsparse_docker \\
+         deepsparse.server --task <TASK-NAME> --model_path /home/deployment
+        ```
     """
     return "".join((stub_info, metrics_info, download_instructions))
 

--- a/tests/sparsify/package/test_cli.py
+++ b/tests/sparsify/package/test_cli.py
@@ -63,22 +63,25 @@ def test_value_error_when_dataset_and_task_not_provided(package_function, cli_ar
     ],
 )
 @patch("sparsify.package_module.cli.package")
-def test_valid_invocation(package_function, cli_args):
+@patch("sparsify.package_module.cli._download_deployment_directory")
+def test_valid_invocation(mocked_download_func, package_function, cli_args):
+    mocked_download_func.return_value = "."
     result = _run_with_cli_runner(cli_args.split())
     assert result.exit_code == 0
 
 
 @pytest.mark.parametrize(
-    "results, metrics",
+    "results",
     [
-        ({"stub": "zoo://", "metrics": (99, -234567)}, ["accuracy", "compression"]),
+        {"stub": "zoo://", "metrics": {"accuracy": 99, "compression": 234567}},
     ],
 )
-def test_get_template_has_model_metrics(results, metrics):
-    output = _get_template(results=results, metrics=metrics)
+@patch("sparsify.package_module.cli._download_deployment_directory")
+def test_get_template_has_model_metrics(mocked_function, results):
+    mocked_function.return_value = "."
+    output = _get_template(results=results)
     assert isinstance(output, str)
-    for metric in results.get("metrics"):
-        assert str(abs(metric)) in output
+    assert str(results.get("metrics")) in output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The following PR accomplishes the following:

- Adds a `Dockerfile` to build and install `deepsparse.server`
- Downloads deployment directory
- Update instructions for user
- Update tests

The new user instructions allow the user to input just one command inside sparsify/docker directory to install all dependencies and deploy a deepsparse server with the most appropriate model from `sparsify.package`

Example User instructions look like the following:

downloading...: 100%|████████████████████████| 104M/104M [00:08<00:00, 12.5MB/s]
downloading...: 100%|████████████████████████| 455k/455k [00:00<00:00, 3.18MB/s]
downloading...: 100%|███████████████████████████| 718/718 [00:00<00:00, 493kB/s]
downloading...: 100%|███████████████████████████| 384/384 [00:00<00:00, 275kB/s]

        Relevant Stub: zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/12layer_pruned80_quant-none-vnni
    
        Model Metrics: {'accuracy': 1, 'compression': 234556}
        
        Use the dockerfile in sparsify/docker/Dockerfile to build deepsparse
        image and run the `deepsparse.server` container. 
        
        Run the following command inside `sparsify/Docker`
        directory (Note: replace <TASK-NAME> with appropriate task):
        
        ```bash        
        docker build -t deepsparse_docker . && docker run -it \
        -v /home/rahul/.cache/sparsezoo/ff56c9e7-d2d8-43aa-ba44-1727aa2d4a51/deployment:/home/deployment  deepsparse_docker \
         deepsparse.server --task <TASK-NAME> --model_path /home/deployment
        ```
        
        
A few end to end example commands:

```
Example for using sparsify.package:
    1) `sparsify.package --task image_classification \
  --optimizing_metric accuracy`
    2) `sparsify.package --task ic --optimizing_metric "accuracy, compression" \
--target VNNI`
```