### PR TITLE
bump main to 1.4.0 (#167)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparsify",
-  "version": "1.2.0",
+  "version": "1.4.0",
   "private": true,
   "dependencies": {
     "@apollo/react-hooks": "^3.1.3",
@@ -19,7 +19,7 @@
     "d3-format": "^1.4.4",
     "fontsource-roboto": "^2.1.4",
     "lodash.debounce": "^4.0.8",
-    "moment": "^2.29.2",
+    "moment": "^2.29.4",
     "prop-types": "^15.7.2",
     "query-string": "^6.13.2",
     "ramda": "^0.27.0",

--- a/src/sparsify/version.py
+++ b/src/sparsify/version.py
@@ -19,7 +19,7 @@ Functionality for storing and setting the version info for Sparsify
 from datetime import date
 
 
-version_base = "1.2.0"
+version_base = "1.4.0"
 is_release = False  # change to True to set the generated version as a release version
 
 


### PR DESCRIPTION
Cherry pick version commit from `main` to `sparsify.alpha`
Co-authored-by: dhuang <dhuang@MacBook-Pro.local>