### PR TITLE
[Add] `sparsify.login` CLI and function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ def _setup_entry_points() -> Dict:
     return {
         "console_scripts": [
             "sparsify.run=sparsify.cli.run:main",
+            "sparsify.login=sparsify.login:main",
         ]
     }
 

--- a/src/sparsify/__init__.py
+++ b/src/sparsify/__init__.py
@@ -14,3 +14,5 @@
 
 # flake8: noqa
 # isort: skip_file
+
+from .login import *

--- a/src/sparsify/auto/utils/nm_api.py
+++ b/src/sparsify/auto/utils/nm_api.py
@@ -21,14 +21,15 @@ from typing import Tuple
 
 import requests
 
+from sparsify.login import import_sparsifyml_authenticated
 from sparsify.schemas import APIArgs, Metrics, SparsificationTrainingConfig
 from sparsify.utils import get_base_url, strtobool
 
 
-try:
-    from sparsifyml.auto import auto_training_config_initial, auto_training_config_tune
-except (ImportError, ModuleNotFoundError):
-    warnings.warn("failed to import sparsifyml", ImportWarning)
+sparsifyml = import_sparsifyml_authenticated()
+
+from sparsifyml.auto import auto_training_config_initial, auto_training_config_tune
+
 
 __all__ = ["api_request_config", "api_request_tune", "request_student_teacher_configs"]
 

--- a/src/sparsify/auto/utils/nm_api.py
+++ b/src/sparsify/auto/utils/nm_api.py
@@ -16,7 +16,6 @@
 Helper functions for communicating with the Neural Magic API
 """
 import os
-import warnings
 from typing import Tuple
 
 import requests
@@ -28,7 +27,10 @@ from sparsify.utils import get_base_url, strtobool
 
 sparsifyml = import_sparsifyml_authenticated()
 
-from sparsifyml.auto import auto_training_config_initial, auto_training_config_tune
+from sparsifyml.auto import (  # noqa: E402
+    auto_training_config_initial,
+    auto_training_config_tune,
+)
 
 
 __all__ = ["api_request_config", "api_request_tune", "request_student_teacher_configs"]

--- a/src/sparsify/login.py
+++ b/src/sparsify/login.py
@@ -30,7 +30,7 @@ from pathlib import Path
 
 import requests
 
-from .version import __version__
+from .version import version_major_minor
 
 
 __all__ = ["login"]
@@ -76,7 +76,7 @@ def authenticate():
     try:
         import sparsifyml
 
-        if sparsifyml.__version__ != __version__:
+        if sparsifyml.version_major_minor != version_major_minor:
             do_login = True
 
     except ModuleNotFoundError:

--- a/src/sparsify/login.py
+++ b/src/sparsify/login.py
@@ -57,7 +57,7 @@ def login(api_key: str) -> None:
     """
     access_token = _refresh_access_token_for_api_key(api_key)
 
-    print("Logged in successfully, installing sparsifyml...")
+    print("Logged in successfully.")
 
     _maybe_install_sparsifyml(access_token)
 

--- a/src/sparsify/login.py
+++ b/src/sparsify/login.py
@@ -35,7 +35,7 @@ from .version import __version__
 
 __all__ = ["login"]
 
-_URL = "https://authentication.griffin.external.neuralmagic.com/v1/connect/token"
+_URL = "https://accounts.neuralmagic.com/v1/connect/token"
 
 _CREDENTIALS_PATH = Path.home().joinpath(".confg", "neuralmagic", "credentials.json")
 
@@ -108,9 +108,9 @@ def _refresh_access_token_for_api_key(api_key: str) -> str:
         headers={"Content-Type": "application/x-www-form-urlecoded"},
         data={
             "grant_type": "password",
-            "username": "api_key",
+            "username": "api-key",
             "password": api_key,
-            "score": "pypi:read",
+            "scope": "pypi:read",
         },
     )
 

--- a/src/sparsify/login.py
+++ b/src/sparsify/login.py
@@ -62,7 +62,7 @@ def login(api_key: str) -> None:
 
 
 class InvalidApiKey(Exception):
-    ...
+    """The API key was invalid"""
 
 
 def main():

--- a/src/sparsify/login.py
+++ b/src/sparsify/login.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+
+import requests
+
+
+__ALL__ = ["login"]
+
+_URL = "https://authentication.griffin.external.neuralmagic.com/v1/connect/token"
+_CREDENTIALS_PATH = "~/.cache/sparsify/credentials.json"
+_ERROR_MESSAGE = (
+    "Sorry, we were unable to authenticate your Neural Magic Account API key. "
+    "If you believe this is a mistake, contact support@neuralmagic.com "
+    "to help remedy this issue."
+)
+
+
+def login(api_key: str) -> None:
+    """
+    Logs into sparsify.
+
+    :param api_key: The API key copied from your account.
+    :raises InvalidApiKey: if the API key is invalid
+    """
+    response = requests.post(
+        _URL,
+        headers={"Content-Type": "application/x-www-form-urlecoded"},
+        data={
+            "grant_type": "password",
+            "username": "api_key",
+            "password": api_key,
+            "score": "pypi:read",
+        },
+    )
+
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as e:
+        raise InvalidApiKey(_ERROR_MESSAGE) from e
+
+    if response.status_code != 200:
+        raise ValueError(f"Unknown response code {response.status_code}")
+
+    with open(os.path.expanduser(_CREDENTIALS_PATH), "w") as fp:
+        fp.write(str(response.content))
+
+    print("Logged in successfully.")
+
+
+class InvalidApiKey(Exception):
+    ...
+
+
+def main():
+    parser = argparse.ArgumentParser("Log into sparsify locally.")
+    parser.add_argument(
+        "api_key",
+        type=str,
+        help="API key copied from your account.",
+    )
+    login(**vars(parser.parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sparsify/login.py
+++ b/src/sparsify/login.py
@@ -142,7 +142,7 @@ def _maybe_install_sparsifyml(access_token: str):
                 "-m",
                 "pip",
                 "install",
-                "--index",
+                "--index-url",
                 _SPARSIFYML_URL_TEMPLATE.format(access_token),
                 f"sparsifyml!={version_major_minor}",
             ]

--- a/src/sparsify/login.py
+++ b/src/sparsify/login.py
@@ -12,6 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+usage: Log into sparsify locally. [-h] api_key
+
+positional arguments:
+  api_key     API key copied from your account.
+
+optional arguments:
+  -h, --help  show this help message and exit
+"""
+
 import argparse
 import json
 import subprocess

--- a/src/sparsify/login.py
+++ b/src/sparsify/login.py
@@ -144,7 +144,7 @@ def _maybe_install_sparsifyml(access_token: str):
                 "install",
                 "--index-url",
                 _SPARSIFYML_URL_TEMPLATE.format(access_token),
-                f"sparsifyml!={version_major_minor}",
+                f"sparsifyml_nightly>={version_major_minor}",
             ]
         )
 

--- a/src/sparsify/login.py
+++ b/src/sparsify/login.py
@@ -79,7 +79,7 @@ def login(api_key: str) -> None:
     Logs into sparsify.
 
     :param api_key: The API key copied from your account
-    :raises InvalidApiKey: if the API key is invalid
+    :raises InvalidAPIKey: if the API key is invalid
     """
     access_token = get_access_token(api_key)
     overwrite_credentials(api_key=api_key)

--- a/src/sparsify/one_shot/api.py
+++ b/src/sparsify/one_shot/api.py
@@ -20,15 +20,8 @@ from sparsify.login import import_sparsifyml_authenticated
 from sparsify.utils import constants
 
 
-try:
-    from sparsifyml import one_shot
-except ImportError as e:
-
-    class SparsifyLoginRequired(Exception):
-        """Exception when sparsifyml has not been installed by sparsify.login"""
 sparsifyml = import_sparsifyml_authenticated()
-from sparsifyml import one_shot
-
+from sparsifyml import one_shot  # noqa: E402
 
 
 __all__ = [

--- a/src/sparsify/one_shot/api.py
+++ b/src/sparsify/one_shot/api.py
@@ -16,6 +16,7 @@
 import argparse
 from pathlib import Path
 
+from sparsify.login import import_sparsifyml_authenticated
 from sparsify.utils import constants
 
 
@@ -25,8 +26,9 @@ except ImportError as e:
 
     class SparsifyLoginRequired(Exception):
         """Exception when sparsifyml has not been installed by sparsify.login"""
+sparsifyml = import_sparsifyml_authenticated()
+from sparsifyml import one_shot
 
-    raise SparsifyLoginRequired("Use `sparsify.login` to enable this command.") from e
 
 
 __all__ = [

--- a/src/sparsify/utils/exceptions.py
+++ b/src/sparsify/utils/exceptions.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-class InvalidApiKey(Exception):
+class InvalidAPIKey(Exception):
     """The API key was invalid"""
 
 

--- a/src/sparsify/utils/exceptions.py
+++ b/src/sparsify/utils/exceptions.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class InvalidApiKey(Exception):
+    """The API key was invalid"""
+
+
+class SparsifyLoginRequired(Exception):
+    """Run `sparsify.login`"""

--- a/src/sparsify/utils/helpers.py
+++ b/src/sparsify/utils/helpers.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import requests
 
-from sparsify.utils.exceptions import InvalidApiKey
+from sparsify.utils.exceptions import InvalidAPIKey
 
 
 __all__ = [
@@ -128,7 +128,7 @@ def get_access_token(api_key: str) -> str:
             "If you believe this is a mistake, contact support@neuralmagic.com "
             "to help remedy this issue."
         )
-        raise InvalidApiKey(error_message) from http_error
+        raise InvalidAPIKey(error_message) from http_error
 
     if response.status_code != 200:
         raise ValueError(f"Unknown response code {response.status_code}")

--- a/src/sparsify/utils/helpers.py
+++ b/src/sparsify/utils/helpers.py
@@ -113,8 +113,6 @@ def get_access_token(api_key: str) -> str:
             "grant_type": "password",
             "username": "api-key",
             "client_id": "ee910196-cd8a-11ed-b74d-bb563cd16e9d",
-            # TODO: Use this value instead of the above once the API is updated
-            # "client_id": "sparsify-python",
             "password": api_key,
             "scope": "pypi:read",
         },

--- a/src/sparsify/utils/helpers.py
+++ b/src/sparsify/utils/helpers.py
@@ -12,7 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+import json
+import logging
+from pathlib import Path
+
+import requests
+
+from sparsify.utils.exceptions import InvalidApiKey
+
+
 __all__ = [
+    "credentials_exists",
+    "get_access_token",
+    "get_authenticated_pypi_url",
+    "get_sparsify_credentials_path",
+    "get_token_url",
+    "overwrite_credentials",
+    "set_log_level",
     "strtobool",
 ]
 _MAP = {
@@ -30,6 +47,8 @@ _MAP = {
     "0": False,
 }
 
+_LOGGER = logging.getLogger(__name__)
+
 
 def strtobool(value):
     """
@@ -43,3 +62,98 @@ def strtobool(value):
         return _MAP[str(value).lower()]
     except KeyError:
         raise ValueError('"{}" is not a valid bool value'.format(value))
+
+
+def get_token_url():
+    """
+    :return: The url to use for getting an access token
+    """
+    return "https://accounts.neuralmagic.com/v1/connect/token"
+
+
+def get_sparsify_credentials_path() -> Path:
+    """
+    :return: The path to the neuralmagic credentials file
+    """
+    return Path.home().joinpath(".config", "neuralmagic", "credentials.json")
+
+
+def credentials_exists() -> bool:
+    """
+    :return: True if the credentials file exists, False otherwise
+    """
+    return get_sparsify_credentials_path().exists()
+
+
+def overwrite_credentials(api_key: str) -> None:
+    """
+    Overwrite the credentials file with the given api key
+    or create a new file if it does not exist
+
+    :param api_key: The api key to write to the credentials file
+    """
+    credentials_path = get_sparsify_credentials_path()
+    credentials_path.parent.mkdir(parents=True, exist_ok=True)
+    credentials = {"api_key": api_key}
+
+    with credentials_path.open("w") as fp:
+        json.dump(credentials, fp)
+
+
+def get_access_token(api_key: str) -> str:
+    """
+    Get the access token for the given api key
+
+    :param api_key: The api key to use for authentication
+    :return: The requested access token
+    """
+    response = requests.post(
+        get_token_url(),
+        data={
+            "grant_type": "password",
+            "username": "api-key",
+            "client_id": "ee910196-cd8a-11ed-b74d-bb563cd16e9d",
+            # TODO: Use this value instead of the above once the API is updated
+            # "client_id": "sparsify-python",
+            "password": api_key,
+            "scope": "pypi:read",
+        },
+    )
+
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as http_error:
+        error_message = (
+            "Sorry, we were unable to authenticate your Neural Magic Account API key. "
+            "If you believe this is a mistake, contact support@neuralmagic.com "
+            "to help remedy this issue."
+        )
+        raise InvalidApiKey(error_message) from http_error
+
+    if response.status_code != 200:
+        raise ValueError(f"Unknown response code {response.status_code}")
+
+    _LOGGER.info("Successfully authenticated with Neural Magic Account API key")
+    return response.json()["access_token"]
+
+
+def get_authenticated_pypi_url(access_token: str) -> str:
+    """
+    Get the authenticated pypi url for the given access token
+
+    :return: The authenticated pypi url
+    """
+    pypi_url_template = "https://nm:{}@pypi.neuralmagic.com"
+    return pypi_url_template.format(access_token)
+
+
+def set_log_level(logger: logging.Logger, level: int) -> None:
+    """
+    Set the log level for the given logger and all of its handlers
+
+    :param logger: The logger to set the level for
+    :param level: The level to set the logger to
+    """
+    logging.basicConfig(level=level)
+    for handler in logger.handlers:
+        handler.setLevel(level=level)


### PR DESCRIPTION
This PR adds a `sparsify.login` utility to authenticate users with a valid `api_key` from sparsify cloud;
After authentication, the utility saves credentials at `~/.config/neuralmagic/credentials.json` and goes onto
install proprietary `sparsifyml` dependency from Neural Magic PyPi Server


As of now, we only have `sparsifyml_nightly` pushed up; this should change to `sparsifyml` once the package is updated.

Usage:
```bash
Usage: sparsify.login [OPTIONS]

  sparsify.login utility to log into sparsify locally.

Options:
  --api-key TEXT  API key copied from your account.  [required]
  --version       Show the version and exit.  [default: False]
  --help          Show this message and exit.  [default: False]
```

example:
```bash
sparsify.login --api-key [API-KEY]
```

Note: Kindly reach out for a dummy test api key if needed.

Test plan:
Ran example command with dummy api-key manually and verified the right version of `sparsifyml` was installed
