### PR TITLE
[Create] alpha implementation

### DIFF
--- a/src/sparsify/create/README.MD
+++ b/src/sparsify/create/README.MD
@@ -69,7 +69,7 @@ SCALER = ...
 
 # initialize sparsify.create and override the SCALER
 sparsification_manager, SCALER = sparsify.create.initialize(
-    MODEL, OPTIMIZER, STEPS_PER_EPOCH
+    MODEL, OPTIMIZER, STEPS_PER_EPOCH, scaler=SCALER
 )
 ```
 
@@ -102,7 +102,7 @@ Example of distillation with a custom teacher:
 DISTILLATION_TEACHER = ...
 
 # initialize sparsify.create and override the SCALER
-sparsification_manager, SCALER = sparsify.create.initialize(
+sparsification_manager, OPTIMIZER = sparsify.create.initialize(
     MODEL,
     OPTIMIZER,
     STEPS_PER_EPOCH,
@@ -116,7 +116,7 @@ sparsification_manager, SCALER = sparsify.create.initialize(
 Sparse transfer learning may be enabled by setting pruning to `transfer` in `initialize`:
 ```python
 # extending the original example
-sparsification_manager, SCALER = sparsify.create.initialize(
+sparsification_manager, OPTIMIZER = sparsify.create.initialize(
     MODEL, OPTIMIZER, STEPS_PER_EPOCH, pruning="constant"
 )
 ```

--- a/src/sparsify/create/README.MD
+++ b/src/sparsify/create/README.MD
@@ -1,0 +1,122 @@
+# Sparsify Create
+
+Sparsify Create is a tool to automatically generate sparsification recipes and apply them to
+custom training aware scenarios.
+
+This document outlines basic usage of `sparsify.create`. For a full list of arguments, check the docstring.
+
+
+## Usage
+The main entrypoint of `sparsify.create` is the `initialize` function. `initialize` takes a pytorch
+model, optimizer, and number of steps in each epoch, creates a sparsification recipe, and wraps the
+training script to incorporate sparsification in the existing training process.
+
+`sparsify.create.initialize` should be called **after** the model, optimizer, and dataloader
+(for determining number of steps per epoch) have been created but **before** the training process starts.
+
+
+```python
+import sparsify
+
+# EXISTING TRAINING VARIABLES
+MODEL = ...
+OPTIMIZER = ...
+STEPS_PER_EPOCH = ...  # len(DATALOADER)
+
+# initialize sparsify.create
+sparsification_manager, OPTIMIZER = sparsify.create.initialize(
+    MODEL, OPTIMIZER, STEPS_PER_EPOCH
+)
+
+# if the script has an end epoch, update it from the manager
+END_EPOCH = sparsification_manager.max_epochs
+```
+
+
+## Recipe Variables
+The `recipe_variables` argument may be used to override particular values related to the sparsification
+recipe. This may include, epochs, pruning type, target hardware, and distillation hyper parameters.
+
+`recipe_variables` must be specified as a `RecipeVariables` schema or dictionary containing the valid
+variables. `RecipeVariables` schema and help text is included in `schemas.py`.
+
+
+## Additional Integration Notes
+This section contains notes on additional updates that are useful for best practice with `sparsify.create`.
+
+### Max Epochs
+As noted above, once sparsificaiton starts, it sets a new internal max epoch. To account for this
+any end epoch that exists in the script should be updated according to the `sparsification_manager`:
+
+```python
+END_EPOCH = sparsification_manager.max_epochs
+```
+
+### Learning Rate Schedulers
+`sparsify.create` creates a sparsification recipe that has its own learning rate scheduler. To avoid
+learning rate conflicts, any existing learning rate schedulers should be disabled.  The kind of learning
+rate scheudule used may be set with the `lr` parameter of `initialize()` and start and end LRs may
+be set with `RecipeVariables`.
+
+### Mixed Precision Training
+If the integrated script supports mixed precision (FP16) training, it is likley using a torch `Scaler` object.
+Since this is the object that will be used for `.step()` updates instead of the `optimizer` it should also
+be passed to initialize and will instead be returned as an updated object:
+
+```python
+# extending the original example
+SCALER = ...
+
+# initialize sparsify.create and override the SCALER
+sparsification_manager, SCALER = sparsify.create.initialize(
+    MODEL, OPTIMIZER, STEPS_PER_EPOCH
+)
+```
+
+#### Quantization and Mixed Precision
+PyTorch does not support FP16 training with quantization, thus when quantization begins, mixed precision should
+be disabled. This can be done by setting `enabled=False` in the scaler and any context managers used in training
+for autocast.
+
+This will also cause an increase in GPU memory usage so the batch size should be adjusted to accommodate.
+
+The epoch that quantization can starts can be found with the following snippet, if it exists, mixed precision
+should be disabled after the `quantization_start_epoch`
+
+```python
+if sparsification_manager.quantization_modifiers:
+    quantization_start_epoch = min(
+        modifier.start_epoch
+        for modifier in sparsification_manager.quantization_modifiers
+    )
+```
+
+### Distillation
+`sparsify.create` supports model distillation - to enable `distillation` should be set to `True`
+in `initialize`.  Self distillation will be used by default, however a distillation teacher may
+be passed to `initialize`.
+
+Example of distillation with a custom teacher:
+```python
+# extending the original example
+DISTILLATION_TEACHER = ...
+
+# initialize sparsify.create and override the SCALER
+sparsification_manager, SCALER = sparsify.create.initialize(
+    MODEL,
+    OPTIMIZER,
+    STEPS_PER_EPOCH,
+    distillation=True,
+    distillation_teacher=DISTILLATION_TEACHER,
+)
+```
+
+
+### Sparse Transfer Learning
+Sparse transfer learning may be enabled by setting pruning to `transfer` in `initialize`:
+```python
+# extending the original example
+sparsification_manager, SCALER = sparsify.create.initialize(
+    MODEL, OPTIMIZER, STEPS_PER_EPOCH, pruning="constant"
+)
+```

--- a/src/sparsify/create/__init__.py
+++ b/src/sparsify/create/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Interface and utilities for sparsify.create
+"""
+
+# flake8: noqa
+from .api import *
+from .schemas import *

--- a/src/sparsify/create/api.py
+++ b/src/sparsify/create/api.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+User facing API entrypoints for sparsify.create
+"""
+
+import logging
+from typing import Any, Dict, Optional, Union
+
+import torch
+from torch.nn import Module
+
+from sparseml.pytorch.optim import ScheduledModifierManager
+from sparsify.create.schemas import RecipeVariables
+from sparsifyml.create import create_recipe
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def initialize(
+    model: Module,
+    optimizer: torch.optim.Optimizer,
+    steps_per_epoch: int,
+    pruning: Union[str, bool, None] = True,
+    quantization: Union[bool, str] = True,
+    lr: str = "linear",
+    distillation: bool = False,
+    distillation_teacher: Optional[Module] = None,
+    scaler: Optional[torch.cuda.amp.GradScaler] = None,
+    recipe_variables: Union[RecipeVariables, Dict[str, Any], None] = None,
+):
+    """
+    Prepares a pytorch model and optimizer for sparsification. Under the hood,
+    a sparsification recipe will be created and initialized with SparseML to
+    apply the desired optimizations
+
+    :param model: PyTorch Module to sparsify
+    :param optimizer: the optimizer used in model training
+    :param steps_per_epoch: number of steps (batches) in each epoch
+    :param pruning: optional pruning algorithm to use in the recipe, can be any of the
+        following, `true` (represents Magnitude/Global-Magnitude pruning according to
+        global_sparsity), `false` (No pruning), `acdc`, `mfac`, `movement`, `obs`,
+        `constant`, `transfer`, or `sparse-transfer`. Defaults to `true`
+    :param quantization: `True` if quantization needs to be applied else `False`.
+        Defaults to `True`
+    :param lr: the learning rate schedule function. Defaults to `linear`
+    :param distillation: if `True` distillation will be added to the recipe.
+        distillation_teacher should also be provided to initialize distillation if
+        using a custom teacher. Will default to 'self' distillation if distillation
+        is enabled with no teacher set
+    :param scaler: scaler used to wrap optimizer for mix precision training, may be
+        any object that wraps the optimizer `step` call
+    :param distillation_teacher: teacher Module to use with distillation if enabled,
+        defaults to self distillation if None provided
+    :param recipe_variables: additional variables to override training with
+    :return: tuple of the sparsification manager
+        (`sparseml.pytorch.optim.ScheduledModifierManager`) and the wrapped optimizer
+        object (scaler if provided otherwise optimizer)
+    """
+
+    # create recipe from sparsifyml
+    _LOGGER.info(
+        f"[sparsify] Creating recipe with pruning={pruning}, "
+        f"quantization={quantization}, distilation={distillation}"
+    )
+    if pruning in ["transfer", "sparse-transfer"]:
+        pruning = "constant"
+    recipe_variables = recipe_variables or RecipeVariables()  # get defaults
+    recipe = create_recipe(
+        model=model,
+        pruning=pruning,
+        quantization=quantization,
+        distillation=distillation,
+        lr=lr,
+        recipe_variables=recipe_variables,
+    )
+
+    _LOGGER.info(
+        "Initializing sparsification by wrapping "
+        f"{scaler.__class__.__name__ or 'optimizer'}"
+    )
+    manager = ScheduledModifierManager.from_yaml(recipe)
+    manager.initialize(
+        module=model,
+        epoch=0.0,
+        distillation_teacher=distillation_teacher or "self",
+    )
+
+    wrapped_optim = manager.modify(
+        model,
+        optimizer,
+        steps_per_epoch=steps_per_epoch,
+        wrap_optim=scaler,
+    )
+
+    return manager, wrapped_optim

--- a/src/sparsify/create/api.py
+++ b/src/sparsify/create/api.py
@@ -37,8 +37,7 @@ def initialize(
     pruning: Union[str, bool, None] = True,
     quantization: Union[bool, str] = True,
     lr: str = "linear",
-    distillation: bool = False,
-    distillation_teacher: Optional[Module] = None,
+    distillation_teacher: Optional[Union[str, Module]] = None,
     scaler: Optional[torch.cuda.amp.GradScaler] = None,
     recipe_variables: Union[RecipeVariables, Dict[str, Any], None] = None,
 ):

--- a/src/sparsify/create/schemas.py
+++ b/src/sparsify/create/schemas.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Schemas for supporting sparsify.create
+"""
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+__all__ = [
+    "RecipeVariables",
+]
+
+
+class RecipeVariables(BaseModel):
+    """
+    Standardized recipe variables that may be overwritten in auto-generated recipes
+    """
+
+    # Training Vars
+    num_epochs: float = Field(default=20.0, description="total epochs")
+    init_lr: float = Field(default=1e-3, description="initial LR before scheduling")
+    final_lr: float = Field(default=1e-7, description="target LR for end of scheduler")
+    target: Optional[str] = Field(
+        default=None, description="target hardware for deployment. ('vnni', 'tensorrt')"
+    )
+    # Sparsification Vars
+    sparsity: float = Field(default=0.8, description="target pruning final sparsity")
+    mask_type: str = Field(default="unstructured", description="pruning type/structure")
+    global_sparsity: bool = Field(
+        default=True, description="global/layerwise sparsity when set to True/False"
+    )
+    # Distillation Vars
+    hardness: float = Field(default=0.5, description="distillation hardness")
+    temperature: float = Field(default=2.0, description="distillation temperature")

--- a/tests/sparsify/create/__init__.py
+++ b/tests/sparsify/create/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/sparsify/create/test_api.py
+++ b/tests/sparsify/create/test_api.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from torch.nn import Module
+
+from sparseml.pytorch.models import mobilenet
+from sparsify.create import initialize
+
+
+def _module_is_quantized(module: Module) -> bool:
+    return any(
+        submodule.__class__.__name__ == "FakeQuantize" for submodule in module.modules()
+    )
+
+
+def _module_sparsity(module: Module):
+    total_params = 0.0
+    total_nonzero = 0.0
+
+    for name, parameter in module.named_parameters():
+        if ".weight" not in name or "conv" not in name:
+            continue
+        total_params += parameter.data.numel()
+        total_nonzero += parameter.data.count_nonzero()
+
+    if total_params == 0:
+        return 0
+
+    return 1 - (total_nonzero / total_params)
+
+
+def test_create_initialize_and_recipe_apply_mobilenet():
+
+    model = mobilenet(pretrained=True)
+    optim = torch.optim.SGD(model.parameters(), lr=0.1)
+
+    # sanity check
+    assert not _module_is_quantized(model)
+    assert _module_sparsity(model) < 0.01
+
+    manager, optim = initialize(model, optim, 4)
+    # check manager content
+    assert manager.pruning_modifiers
+    assert manager.quantization_modifiers
+    assert not manager.distillation_modifiers
+    assert optim.__class__.__name__ == "RecipeManagerStepWrapper"
+
+    # emulate entire range of training steps
+    for _ in range(20 * 4 + 1):
+        optim.step()
+
+    # check expected structure post training
+    assert _module_is_quantized(model)
+    assert abs(_module_sparsity(model) - 0.8) < 0.05


### PR DESCRIPTION
`sparsify.create` API pathway that creates a recipe and automatically enables sparsification aware training via sparseml.

Documentation of current capabilities included in the `README.MD`.

follow ups: Loggers

**test_plan:**
Simple E2E test included using mobilenet and simulated training steps