### PR TITLE
Remove hardware optimization options

### DIFF
--- a/src/sparsify/cli/opts.py
+++ b/src/sparsify/cli/opts.py
@@ -125,6 +125,15 @@ RECIPE = click.option(
     "--recipe", default=None, type=str, help="Recipe to override automatic recipe."
 )
 RECIPE_ARGS = click.option("--recipe-args", default=None, type=str)
+OPTIM_LEVEL = click.option(
+    "--optim-level",
+    default=0.5,
+    type=float,
+    help=(
+        "Preferred tradeoff between accuracy and performance. Float value in the range "
+        "[0, 1]. Default 0.5"
+    ),
+)
 
 
 def add_info_opts(f):

--- a/src/sparsify/cli/opts.py
+++ b/src/sparsify/cli/opts.py
@@ -34,12 +34,6 @@ __all__ = [
     "DEPLOY_SCENARIO",
     "RECIPE",
     "RECIPE_ARGS",
-    "OPTIM_LEVEL",
-    "OPTIM_FOR_HARDWARE",
-    "MAX_LATENCY",
-    "MIN_THROUGHPUT",
-    "MAX_SIZE",
-    "MAX_MEMORY",
     "add_data_opts",
     "add_deploy_opts",
     "add_info_opts",
@@ -49,7 +43,6 @@ __all__ = [
 
 _EXPERIMENT_TYPES = ["sparse-transfer", "one-shot", "training-aware"]
 _EVAL_METRICS = ["kl", "accuracy", "mAP", "recall", "f1"]
-_OPTIM_LEVELS = ["balanced", "throughput", "latency", "size", "memory"]
 _DEPLOY_ENGINES = ["deepsparse", "onnxruntime"]
 
 EXPERIMENT_TYPE = click.option(
@@ -132,18 +125,6 @@ RECIPE = click.option(
     "--recipe", default=None, type=str, help="Recipe to override automatic recipe."
 )
 RECIPE_ARGS = click.option("--recipe-args", default=None, type=str)
-OPTIM_LEVEL = click.option(
-    "--optim-level",
-    default=_OPTIM_LEVELS[0],
-    type=click.Choice(_OPTIM_LEVELS),
-    help="What to optimize the model for.",
-)
-OPTIM_FOR_HARDWARE = click.option("--optim-for-hardware", default=False, is_flag=True)
-
-MAX_LATENCY = click.option("--max-latency", default=None, type=int)
-MIN_THROUGHPUT = click.option("--min-throughput", default=None, type=int)
-MAX_SIZE = click.option("--max-size", default=None, type=int)
-MAX_MEMORY = click.option("--max-memory", default=None, type=int)
 
 
 def add_info_opts(f):
@@ -183,12 +164,6 @@ def add_deploy_opts(f):
 
 def add_optim_opts(f):
     for fn in [
-        MAX_MEMORY,
-        MAX_SIZE,
-        MIN_THROUGHPUT,
-        MAX_LATENCY,
-        OPTIM_FOR_HARDWARE,
-        OPTIM_LEVEL,
         RECIPE_ARGS,
         RECIPE,
     ]:

--- a/src/sparsify/cli/opts.py
+++ b/src/sparsify/cli/opts.py
@@ -34,6 +34,7 @@ __all__ = [
     "DEPLOY_SCENARIO",
     "RECIPE",
     "RECIPE_ARGS",
+    "OPTIM_LEVEL",
     "add_data_opts",
     "add_deploy_opts",
     "add_info_opts",

--- a/src/sparsify/cli/run.py
+++ b/src/sparsify/cli/run.py
@@ -54,6 +54,7 @@ def one_shot(**kwargs):
         num_samples=kwargs["train_samples"] or -1,
         deploy_dir=Path(kwargs["working_dir"]),
         eval_metric=kwargs["eval_metric"],
+        opt_level=kwargs["optim_level"],
         recipe_file=Path(kwargs["recipe"]) if kwargs["recipe"] is not None else None,
         recipe_args=recipe_args,
     )

--- a/src/sparsify/cli/run.py
+++ b/src/sparsify/cli/run.py
@@ -54,7 +54,6 @@ def one_shot(**kwargs):
         num_samples=kwargs["train_samples"] or -1,
         deploy_dir=Path(kwargs["working_dir"]),
         eval_metric=kwargs["eval_metric"],
-        opt_level=kwargs["optim_level"],
         recipe_file=Path(kwargs["recipe"]) if kwargs["recipe"] is not None else None,
         recipe_args=recipe_args,
     )

--- a/src/sparsify/one_shot/api.py
+++ b/src/sparsify/one_shot/api.py
@@ -84,6 +84,17 @@ def main():
         help="Metric that the model is evaluated against on the task.",
     )
 
+    optim = parser.add_argument_group("Optimization")
+    optim.add_argument(
+        "--optim-level",
+        default=0.5,
+        type=int,
+        help=(
+            "Preferred tradeoff between accuracy and performance. Float value in the "
+            "range [0, 1]. Default 0.5"
+        ),
+    )
+
     args = parser.parse_args()
 
     one_shot.one_shot(
@@ -93,6 +104,7 @@ def main():
         num_samples=args.num_samples,
         deploy_dir=Path(args.deploy_dir),
         eval_metric=args.eval_metric,
+        optim_level=args.optim_level,
         recipe_file=Path(args.recipe) if args.recipe is not None else None,
     )
 

--- a/src/sparsify/one_shot/api.py
+++ b/src/sparsify/one_shot/api.py
@@ -84,14 +84,6 @@ def main():
         help="Metric that the model is evaluated against on the task.",
     )
 
-    optim = parser.add_argument_group("Optimization")
-    optim.add_argument(
-        "--opt-level",
-        default="balanced",
-        choices=["balanced", "throughput", "latency", "size", "memory"],
-        help="What to optimize the model for.",
-    )
-
     args = parser.parse_args()
 
     one_shot.one_shot(
@@ -101,7 +93,6 @@ def main():
         num_samples=args.num_samples,
         deploy_dir=Path(args.deploy_dir),
         eval_metric=args.eval_metric,
-        opt_level=args.opt_level,
         recipe_file=Path(args.recipe) if args.recipe is not None else None,
     )
 


### PR DESCRIPTION
Remove hardware optimization targets as options for Sparsify One-Shot and Training-Aware. Instead, optimization will be based on an "optimization target" implemented in other PRs.