### PR TITLE
Sparsify.package

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
 # Setup the base image
 FROM python:3.8-slim-bullseye
+ARG SPARSIFY_API_KEY
 
 # Install git
 RUN : \
@@ -18,8 +19,14 @@ RUN pip3 install --upgrade setuptools wheel
 
 ARG GIT_CHECKOUT
 # if $GIT_CHECKOUT is not specified - just install from pypi
-RUN if [ -z "${GIT_CHECKOUT}" ] ; then pip3 install --no-cache-dir --upgrade deepsparse[server] ; fi
+RUN if [ -z "${GIT_CHECKOUT}" ] ; then pip3 install --no-cache-dir --upgrade sparsify ; fi
 
 # if $GIT_CHECKOUT is specified - clone, checkout $GIT_CHECKOUT, and install with -e
-RUN if [ -n "${GIT_CHECKOUT}" ] ; then git clone https://github.com/neuralmagic/deepsparse.git --depth 1 -b $GIT_CHECKOUT; fi
-RUN if [ -n "${GIT_CHECKOUT}" ] ; then pip3 install --no-cache-dir --upgrade -e "./deepsparse[server]" ; fi
+RUN if [ -n "${GIT_CHECKOUT}" ] ; then git clone https://github.com/neuralmagic/sparsify.git --depth 1 -b $GIT_CHECKOUT; fi
+RUN if [ -n "${GIT_CHECKOUT}" ] ; then pip3 install --no-cache-dir --upgrade -e "./sparsify" ; fi
+
+# Install sparsifyml using sparsify
+RUN sparsify.login --api-key $SPARSIFY_API_KEY
+
+CMD bash
+

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ _deps = [
 _nm_deps = [
     f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_nm_deps}",
     f"{'sparseml' if is_release else 'sparseml-nightly'}[torchvision]~={version_nm_deps}",  # noqa E501
-    f"{'deepsparse[server]' if is_release else 'deepsparse-nightly[server]'}~={version_nm_deps}",
+    f"{'deepsparse[server]' if is_release else 'deepsparse-nightly[server]'}~={version_nm_deps}",  # noqa E501
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ _deps = [
 _nm_deps = [
     f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_nm_deps}",
     f"{'sparseml' if is_release else 'sparseml-nightly'}[torchvision]~={version_nm_deps}",  # noqa E501
-    f"{'deepsparse' if is_release else 'deepsparse-nightly'}~={version_nm_deps}",
+    f"{'deepsparse[server]' if is_release else 'deepsparse-nightly[server]'}~={version_nm_deps}",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ def _setup_entry_points() -> Dict:
             "sparsify.login=sparsify.login:main",
             "sparsify.init=sparsify.init:main",
             "sparsify.apply=sparsify.apply:main",
+            "sparsify.package=sparsify.package:main",
         ]
     }
 

--- a/src/sparsify/package.py
+++ b/src/sparsify/package.py
@@ -79,12 +79,13 @@ def package_instructions(deployment_path: str, task: str):
         image and run the `deepsparse.server`
 
         Run the following command inside `{dockerfile_directory}`
-        directory:
+        directory (Note: replace <API_KEY> with appropriate sparsify api key):
 
         ```bash
-        docker build -t sparsify_docker . && docker run -it \\
-        -v {deployment_path}:/home/deployment  sparsify_docker \\
-         sparsify.server --task {task} --model_path /home/deployment
+        docker build --build-arg SPARSIFY_API_KEY=<API_KEY> -t sparsify_docker . \\
+            && docker run -it -v {deployment_path}:/home/deployment  \\
+                sparsify_docker sparsify.server \\
+                    --task {task} --model_path /home/deployment
         ```
     """
     return deployment_instructions

--- a/src/sparsify/package.py
+++ b/src/sparsify/package.py
@@ -12,10 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# flake8: noqa
-# isort: skip_file
+import logging
 
-from .login import *
-from .init import *
-from .apply import *
-from .package import *
+import click
+from sparsezoo.analyze.cli import CONTEXT_SETTINGS
+from sparsify.utils import set_log_level
+from sparsify.version import version_major_minor
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.version_option(version=version_major_minor)
+@click.option("--debug/--no-debug", default=False, hidden=True)
+def main(debug: bool = False, **kwargs):
+    set_log_level(logger=_LOGGER, level=logging.DEBUG if debug else logging.INFO)
+    _LOGGER.debug(f"locals: {locals()}")

--- a/src/sparsify/package.py
+++ b/src/sparsify/package.py
@@ -75,16 +75,16 @@ def package_instructions(deployment_path: str, task: str):
     dockerfile_directory = Path(__file__).parent.parent / "docker"
     dockerfile_path = dockerfile_directory / "Dockerfile"
     deployment_instructions = f"""
-        Use the dockerfile in {dockerfile_path} to build deepsparse
-        image and run the `deepsparse.server` container.
+        Use the dockerfile in {dockerfile_path} to build sparsify
+        image and run the `deepsparse.server`
 
         Run the following command inside `{dockerfile_directory}`
         directory:
 
         ```bash
-        docker build -t deepsparse_docker . && docker run -it \\
-        -v {deployment_path}:/home/deployment  deepsparse_docker \\
-         deepsparse.server --task {task} --model_path /home/deployment
+        docker build -t sparsify_docker . && docker run -it \\
+        -v {deployment_path}:/home/deployment  sparsify_docker \\
+         sparsify.server --task {task} --model_path /home/deployment
         ```
     """
     return deployment_instructions

--- a/src/sparsify/package.py
+++ b/src/sparsify/package.py
@@ -11,21 +11,80 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""
+Usage: sparsify.package [OPTIONS]
 
+Options:
+  --version                       Show the version and exit.  [default: False]
+  --task [image_classification|object_detection|segmentation|question_answering|
+  text_classification|sentiment_analysis|token_classification]
+                                  The task to package depoyment directory for
+                                  [required]
+  --deployment-dir DIRECTORY      The directory containing the deployment
+                                  files to package  [required]
+  --help                          Show this message and exit.  [default:
+                                  False]
+"""
 import logging
+from pathlib import Path
 
 import click
 from sparsezoo.analyze.cli import CONTEXT_SETTINGS
+from sparsezoo.utils import TASKS_WITH_ALIASES
 from sparsify.utils import set_log_level
 from sparsify.version import version_major_minor
 
 
+__all__ = ["package_instructions"]
 _LOGGER = logging.getLogger(__name__)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.version_option(version=version_major_minor)
+@click.option(
+    "--task",
+    type=click.Choice(TASKS_WITH_ALIASES, case_sensitive=False),
+    help="The task to package depoyment directory for",
+    required=True,
+)
+@click.option(
+    "--deployment-dir",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, readable=True),
+    help="The directory containing the deployment files to package",
+    required=True,
+)
 @click.option("--debug/--no-debug", default=False, hidden=True)
-def main(debug: bool = False, **kwargs):
+def main(
+    deployment_dir: str,
+    task: str,
+    debug: bool = False,
+):
     set_log_level(logger=_LOGGER, level=logging.DEBUG if debug else logging.INFO)
+    print(package_instructions(deployment_path=deployment_dir, task=task))
     _LOGGER.debug(f"locals: {locals()}")
+
+
+def package_instructions(deployment_path: str, task: str):
+    """
+    Returns instructions for packaging a deployment directory for a given task.
+
+    :param deployment_path: The path to the deployment directory
+    :param task: The task to package depoyment directory for
+    :return: The instructions for packaging a deployment directory for a given task
+    """
+    dockerfile_directory = Path(__file__).parent.parent / "docker"
+    dockerfile_path = dockerfile_directory / "Dockerfile"
+    deployment_instructions = f"""
+        Use the dockerfile in {dockerfile_path} to build deepsparse
+        image and run the `deepsparse.server` container.
+
+        Run the following command inside `{dockerfile_directory}`
+        directory:
+
+        ```bash
+        docker build -t deepsparse_docker . && docker run -it \\
+        -v {deployment_path}:/home/deployment  deepsparse_docker \\
+         deepsparse.server --task {task} --model_path /home/deployment
+        ```
+    """
+    return deployment_instructions

--- a/src/sparsify/utils/helpers.py
+++ b/src/sparsify/utils/helpers.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass
 from enum import Enum, unique
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urljoin
 
 import requests
@@ -73,13 +73,22 @@ def strtobool(value):
         raise ValueError('"{}" is not a valid bool value'.format(value))
 
 
-def set_log_level(logger: logging.Logger, level: int) -> None:
+def set_log_level(logger: logging.Logger, level: Union[str, int]) -> None:
     """
     Set the log level for the given logger and all of its handlers
 
     :param logger: The logger to set the level for
     :param level: The level to set the logger to
     """
+    if isinstance(level, str):
+        level = {
+            "debug": logging.DEBUG,
+            "info": logging.INFO,
+            "warn": logging.WARN,
+            "critical": logging.CRITICAL,
+            "error": logging.ERROR,
+        }[level.lower()]
+
     logging.basicConfig(level=level)
     for handler in logger.handlers:
         handler.setLevel(level=level)


### PR DESCRIPTION
A very basic version of `sparsify.package` that when given a deployment directory and a task displays instructions on how to deploy the directory with the dockerfile supplied with this repo

```bash
sparsify.package --experiment ~/models --task ic

        Use the dockerfile in /home/rahul/github_projects/sparsify/src/docker/Dockerfile to build sparsify
        image and run the `deepsparse.server`

        Run the following command inside `/home/rahul/github_projects/sparsify/src/docker`
        directory (Note: replace <API_KEY> with appropriate sparsify api key):

        ```bash
        docker build --build-arg SPARSIFY_API_KEY=<API_KEY> -t sparsify_docker . \
            && docker run -it -v /home/rahul/models:/home/deployment  \
                sparsify_docker deepsparse.server \
                    --task ic --model_path /home/deployment \
                    --log-level info
        ```
```


Usage:
```bash
Usage: sparsify.package [OPTIONS]

Options:
  --version                       Show the version and exit.  [default: False]
  --task [image_classification|image_classification|image-classification|ic|classification|object_detection|object_detection|object-detection|od|detection|segmentation|segmentation|question_answering|question_answering|question-answering|qa|text_classification|text_classification|text-classification|glue|sentiment_analysis|sentiment_analysis|sentiment-analysis|sentiment|token_classification|token_classification|token-classification|ner|named_entity_recognition|named-entity-recognition]
                                  The task to package depoyment directory for
                                  [required]
  --experiment DIRECTORY          The directory containing the deployment
                                  files to package, or sparsify experiment-id
                                  (Not yet supported)  [required]
  --log-level [debug|info|warn|critical|error]
                                  Sets the logging level  [default: info;
                                  required]
  --deploy-type [server]          Sets the deployment type, only supports
                                  `server`  [default: server; required]
  --preprocessing TEXT            Sets the pre-processing function to use
  --postprocessing TEXT           Sets the post-processing function to use
  --help                          Show this message and exit.  [default:
                                  False]
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204285971555464