### PR TITLE
[Alpha] Rework Auto main script into Training-Aware and Sparse-Transfer script

### DIFF
--- a/src/sparsify/auto/scripts/main.py
+++ b/src/sparsify/auto/scripts/main.py
@@ -31,7 +31,7 @@ from tensorboard.program import TensorBoard
 _LOGGER = logging.getLogger("auto_banner")
 
 
-def main(api_args: APIArgs):  # TODO: get rid of pydnatic based args?
+def main(api_args: APIArgs):
     initialize_banner_logger()
 
     # Set up directory for saving

--- a/src/sparsify/auto/scripts/main.py
+++ b/src/sparsify/auto/scripts/main.py
@@ -18,7 +18,7 @@ import shutil
 import time
 import warnings
 from collections import OrderedDict
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 from sparsify.auto.tasks import TaskRunner
 from sparsify.auto.utils import (
@@ -32,296 +32,45 @@ from sparsify.auto.utils import (
     request_student_teacher_configs,
     save_history,
 )
-from sparsify.schemas import APIArgs, Metrics, RunMode, SparsificationTrainingConfig
+from sparsify.schemas import APIArgs, Metrics, SparsificationTrainingConfig
 from tensorboard.program import TensorBoard
 
 
 _LOGGER = logging.getLogger("auto_banner")
 
 
-def main(api_args: Optional[APIArgs] = None):
+# General TODO list
+# TODO: replace optimizing_metric with eval metric
+# TODO: add support for kwargs
+
+# Unresolved questions
+# How are additional trials prompted? How is the info getting passed to the API?
+
+def main(api_args: APIArgs): # TODO: get rid of pydnatic based args?
     initialize_banner_logger()
-
-    # Tuning tracking variables
-    history = {"teacher": [], "student": []}
-    best_n_trial_metrics = {
-        "teacher": OrderedDict(),
-        "student": OrderedDict(),
-    }  # map trail_idx to metrics
-    start_idx = 0
-    resume_stage = None
-
-    # Parse CLI args
-    api_args = api_args or APIArgs.from_cli()
-
-    # Load state from previous run
-    if api_args.resume:
-        _LOGGER.info(f"Resuming run from {api_args.resume}")
-
-        # Load history from YAML file
-        raw_history = load_raw_config_history(api_args.resume)
-
-        # API args to be loaded from history file, all CLI args passed on this call
-        # to be ignored
-        resume_directory = api_args.resume
-        api_args = APIArgs(**raw_history["api_args"])
-        api_args.resume = resume_directory
-
-        # Reconstruct run history
-        history["teacher"] = [
-            (
-                SparsificationTrainingConfig(**trial["config"]),
-                Metrics(**trial["metrics"]),
-            )
-            for trial in raw_history["teacher"].values()
-        ]
-
-        history["student"] = [
-            (
-                SparsificationTrainingConfig(**trial["config"]),
-                Metrics(**trial["metrics"]),
-            )
-            for trial in raw_history["student"].values()
-        ]
-
-        best_n_trial_metrics["teacher"] = best_n_trials_from_history(
-            history["teacher"], api_args.maximum_trial_saves
-        )
-        best_n_trial_metrics["student"] = best_n_trials_from_history(
-            history["student"], api_args.maximum_trial_saves
-        )
-
-        # Only teacher and student stages supported at this time
-        resume_stage = (
-            "student"
-            if (
-                len(history["student"]) > 0
-                or len(history["teacher"]) == api_args.num_trials
-            )
-            else "teacher"
-        )
-        start_idx = len(history[resume_stage])
-
-        # Check whether the run can continue to be tuned
-        config_dict = api_request_tune(history[resume_stage])
-        if config_dict.get("tuning_complete"):
-            if resume_stage == "student":
-                raise ValueError(
-                    "Tuning stop condition already satisfied for provided run. To turn "
-                    "off stopping condition use the `--no_stopping` flag"
-                )
-            else:
-                warnings.warn(
-                    "Tuning stop condition already satisfied for teacher "
-                    "stage. Skipping to training student. To turn off stopping  "
-                    "condition use the `--no_stopping` flag"
-                )
-
-        student_config, teacher_config = None, None
-        if resume_stage == "student":
-            student_config = SparsificationTrainingConfig(**config_dict)
-        else:
-            teacher_config = SparsificationTrainingConfig(**config_dict)
-            if RunMode(api_args.run_mode) != RunMode.teacher_only:
-                student_config = api_request_config(api_args)
-
-        save_directory = api_args.resume
-        base_log_directory = os.path.join(save_directory, "training", "logs")
-        base_artifact_directory = os.path.join(
-            save_directory, "training", "run_artifacts"
-        )
-
-    else:
-        # Request initial training configs
-        student_config, teacher_config = request_student_teacher_configs(api_args)
-
-        # Set up directory for saving
-        (
-            save_directory,
-            base_artifact_directory,
-            base_log_directory,
-        ) = create_save_directory(api_args)
-
+   
+    # Set up directory for saving
+    (
+        save_directory,
+        base_artifact_directory,
+        log_directory,
+    ) = create_save_directory(api_args) # TODO: Update save structure
+    
     # Launch tensorboard server
     tensorboard_server = TensorBoard()
-    tensorboard_server.configure(argv=[None, "--logdir", base_log_directory])
+    tensorboard_server.configure(argv=[None, "--logdir", log_directory])
     url = tensorboard_server.launch()
     print(f"TensorBoard listening on {url}")
-
-    max_tune_trials = api_args.num_trials or float("inf")
-    tuning_start_time = time.time()
-
-    # Train teacher
-    if teacher_config:
-        _LOGGER.info("Starting hyperparameter tuning on teacher model")
-
-        teacher_artifact_directory = os.path.join(base_artifact_directory, "teacher")
-        teacher_log_directory = os.path.join(base_log_directory, "teacher")
-
-        teacher_runner = _train(
-            config=teacher_config,
-            api_args=api_args,
-            history=history["teacher"],
-            best_n_trial_metrics=best_n_trial_metrics["teacher"],
-            start_idx=start_idx,
-            max_tune_trials=max_tune_trials,
-            tuning_start_time=tuning_start_time,
-            artifact_directory=teacher_artifact_directory,
-            log_directory=teacher_log_directory,
-            stage="teacher",
-        )
-
-        # Determine the best teacher trained and assign to student
-        best_trial_idx = max(
-            best_n_trial_metrics["teacher"], key=best_n_trial_metrics["teacher"].get
-        )
-        best_trial_path = get_trial_artifact_directory(
-            teacher_artifact_directory, best_trial_idx
-        )
-        best_teacher_path = os.path.join(
-            best_trial_path, teacher_runner.model_save_name
-        )
-
-        if student_config:
-            student_config.distill_teacher = best_teacher_path
-
-    # Train student
-    if student_config:
-        _LOGGER.info("Starting hyperparameter tuning on student model")
-
-        student_artifact_directory = os.path.join(base_artifact_directory, "student")
-        student_log_directory = os.path.join(base_log_directory, "student")
-
-        student_runner = _train(
-            config=student_config,
-            api_args=api_args,
-            history=history["student"],
-            best_n_trial_metrics=best_n_trial_metrics["student"],
-            start_idx=start_idx
-            if not (api_args.resume and resume_stage == "teacher")
-            else 0,
-            max_tune_trials=max_tune_trials,
-            tuning_start_time=tuning_start_time,
-            artifact_directory=student_artifact_directory,
-            log_directory=student_log_directory,
-            stage="student",
-        )
-
-        # Export student and create deployment directory
-        best_trial_idx = max(
-            best_n_trial_metrics["student"], key=best_n_trial_metrics["student"].get
-        )
-        trial_artifact_directory = get_trial_artifact_directory(
-            student_artifact_directory, best_trial_idx
-        )
-
-        _LOGGER.info(
-            "Tuning complete. Exporting model from the best trial, "
-            f"#{best_trial_idx}"
-        )
-
-        student_runner.export(model_directory=trial_artifact_directory)
-        student_runner.create_deployment_directory(
-            target_directory=save_directory, trial_idx=best_trial_idx
-        )
-
-
-def _train(
-    config: SparsificationTrainingConfig,
-    api_args: APIArgs,
-    history: List[Tuple[SparsificationTrainingConfig, Metrics]],
-    best_n_trial_metrics: Dict[int, Metrics],
-    start_idx: int,
-    max_tune_trials: int,
-    tuning_start_time: float,
-    artifact_directory: str,
-    log_directory: str,
-    stage: str,
-):
-    """
-    Perform hyperparamter tuning by training multiple iterations of the model
-
-    :param config: config to define the initial training running
-    :param api_args: user defined settings
-    :param history: history of runs attempted so far in this experiment. Empty unless
-        the --resume flag was used
-    :param best_n_trial_metrics: mapping of trail_idx to metrics for at most n runs with
-        the best metrics. Empty unless the --resume flag was used
-    :param start_idx: trial number to start on. 0 unless the --resume flag was used
-    :param max_tune_trials: maximum number of tuning trials to run
-    :param tuning_start_time: time at which auto parameter tuning started
-    :param artifact_directory: path to the artifacts directory for this stage
-    :param log directory: path to the logging directory for this stage
-    :param stage: name of stage, used for saving to the run history file
-    """
-    maximum_trial_saves = api_args.maximum_trial_saves or float("inf")
-    trial_idx = start_idx
-
-    # tune until either (in order of precedence):
-    # 1. number of tuning trials used up
-    # 2. maximum tuning time exceeded
-    # 3. tuning early stopping condition met
-    while (
-        trial_idx < max_tune_trials
-        and time.time() - tuning_start_time <= api_args.max_train_time * 60 * 60
-    ):
-        _LOGGER.info(f"Starting tuning trial #{trial_idx}")
-
-        # Create a runner from the config, based on the task specified by config.task
-        runner = TaskRunner.create(config)
-
-        # Execute integration run and return metrics
-        metrics = runner.train(log_directory)
-        log_directory = os.path.join(log_directory, f"trial_{trial_idx}")
-
-        # Move models from temporary directory to save directory, while only keeping
-        # the best n models
-        is_better_than_top_n = any(
-            metrics > best_metrics for best_metrics in best_n_trial_metrics.values()
-        )
-        if (len(best_n_trial_metrics) < maximum_trial_saves) or is_better_than_top_n:
-            runner.move_output(target_directory=artifact_directory, trial_idx=trial_idx)
-            best_n_trial_metrics[trial_idx] = metrics
-
-            _LOGGER.info(
-                f"Trial #{trial_idx} in top {maximum_trial_saves} seen so far. Saving "
-                "to run artifacts directory"
-            )
-
-        # If better trial was saved to a total of n+1 saved trials, drop worst one
-        if len(best_n_trial_metrics) > maximum_trial_saves:
-            drop_trial_idx = min(best_n_trial_metrics, key=best_n_trial_metrics.get)
-            shutil.rmtree(
-                get_trial_artifact_directory(artifact_directory, drop_trial_idx)
-            )
-            del best_n_trial_metrics[drop_trial_idx]
-
-            _LOGGER.info(
-                f"Dropping trial #{drop_trial_idx} from top {maximum_trial_saves} "
-                "saved trials"
-            )
-
-        # save run history as list of pairs of (config, metrics)
-        history.append((config, metrics))
-        save_history(
-            history=history,
-            api_args=api_args,
-            stage=stage,
-            target_directory=artifact_directory,
-        )
-
-        # request a config with a new set of hyperparameters
-        config_dict = api_request_tune(history)
-
-        if config_dict.get("tuning_complete"):
-            break
-
-        config = SparsificationTrainingConfig(**config_dict)
-
-        trial_idx += 1
-
-    return runner
-
-
-if __name__ == "__main__":
-    main()
+    
+    # Request config from api and instantiate runner
+    config = api_request_config(api_args)
+    runner = TaskRunner.create(config)
+    
+    # Execute integration run and return metrics
+    metrics = runner.train(log_directory)
+    runner.move_output(target_directory=artifact_directory, trial_idx=trial_idx) #TODO: save to correct directory immediately?
+    
+    runner.export(model_directory=trial_artifact_directory)
+    runner.create_deployment_directory(
+        target_directory=save_directory, trial_idx=best_trial_idx
+    )

--- a/src/sparsify/auto/tasks/image_classification/args.py
+++ b/src/sparsify/auto/tasks/image_classification/args.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 from pydantic import Field
+from sparseml.pytorch.opset import TORCH_DEFAULT_ONNX_OPSET
 from sparseml.pytorch.utils import default_device
 from sparsify.auto.tasks import BaseArgs
 
@@ -144,7 +145,8 @@ class ImageClassificationExportArgs(_ImageClassificationBaseArgs):
         Default=None, description="required - tag for model under save_dir"
     )
     onnx_opset: int = Field(
-        default=11, description="The onnx opset to use for exporting the model"
+        default=TORCH_DEFAULT_ONNX_OPSET,
+        description="The onnx opset to use for exporting the model",
     )
     num_samples: int = Field(
         default=-1, description="number of forward data output samples to produce"

--- a/src/sparsify/auto/tasks/image_classification/runner.py
+++ b/src/sparsify/auto/tasks/image_classification/runner.py
@@ -123,9 +123,7 @@ class ImageClassificationRunner(TaskRunner):
         """
         Update run directories to save to the temporary run directory
         """
-        self.train_args.save_dir = os.path.join(
-            self.run_directory.name, self.train_args.save_dir
-        )
+        self.train_args.save_dir = self.run_directory.name
         self.train_args.logs_dir = self.log_directory
         self.export_args.checkpoint_path = os.path.join(
             self.run_directory.name, self.export_args.checkpoint_path
@@ -219,8 +217,11 @@ class ImageClassificationRunner(TaskRunner):
             recovery=None,
         )
 
-    def _get_model_artifact_directory(self) -> str:
+    def _get_default_deployment_directory(self, train_directory: str) -> str:
         """
-        Return the absolute path to the temporary run artifacts directory
+        Return the path to where the deployment directory is created by export
+
+        :param train_directory: train directory from which the export directory was
+            created. Used for relative pathing
         """
-        return os.path.join(self.train_args.save_dir, self.train_args.model_tag)
+        return os.path.join(train_directory, "deployment")

--- a/src/sparsify/auto/tasks/image_classification/runner.py
+++ b/src/sparsify/auto/tasks/image_classification/runner.py
@@ -59,8 +59,7 @@ class ImageClassificationRunner(TaskRunner):
     def __init__(self, config: SparsificationTrainingConfig):
         super().__init__(config)
         self._model_save_name = os.path.join(
-            "training",
-            ("model-one-shot.pth" if self.train_args.one_shot else "model.pth"),
+            *self.export_args.checkpoint_path.split(os.sep)[-3:]
         )
 
     @classmethod
@@ -123,10 +122,10 @@ class ImageClassificationRunner(TaskRunner):
         """
         Update run directories to save to the temporary run directory
         """
-        self.train_args.save_dir = self.run_directory.name
+        self.train_args.save_dir = self.run_directory
         self.train_args.logs_dir = self.log_directory
         self.export_args.checkpoint_path = os.path.join(
-            self.run_directory.name, self.export_args.checkpoint_path
+            self.run_directory, self.export_args.checkpoint_path
         )
         self.export_args.save_dir = self.train_args.save_dir
 

--- a/src/sparsify/auto/tasks/image_classification/runner.py
+++ b/src/sparsify/auto/tasks/image_classification/runner.py
@@ -223,4 +223,4 @@ class ImageClassificationRunner(TaskRunner):
         :param train_directory: train directory from which the export directory was
             created. Used for relative pathing
         """
-        return os.path.join(train_directory, "deployment")
+        return os.path.join(train_directory, self.train_args.model_tag, "deployment")

--- a/src/sparsify/auto/tasks/object_detection/yolov5/args.py
+++ b/src/sparsify/auto/tasks/object_detection/yolov5/args.py
@@ -66,6 +66,9 @@ class _Yolov5BaseTrainArgs(BaseArgs):
     project: Union[str, Path] = Field(
         default="train", description="save to project/name"
     )
+    log_dir: Union[str, Path] = Field(
+        default=None, description="optional path to re-route logging to"
+    )
     name: str = Field(default="exp", description="save to project/name")
     exist_ok: bool = Field(
         default=False, description="existing project/name ok, do not increment"
@@ -137,7 +140,6 @@ class Yolov5ExportArgs(BaseArgs):
     )
     half: bool = Field(default=False, description="FP16 half-precision export")
     inplace: bool = Field(default=False, description="set YOLOv5 Detect() inplace=True")
-    train: bool = Field(default=False, description="model.train() mode")
     optimize: bool = Field(
         default=False, description="TorchScript: optimize for mobile"
     )
@@ -150,6 +152,13 @@ class Yolov5ExportArgs(BaseArgs):
     agnostic_nms: bool = Field(
         default=False, description="TF: add agnostic NMS to model"
     )
-    remove_grid: bool = Field(
-        default=False, description="remove export of Detect() layer grid"
+    topk_per_class: int = Field(
+        default=100, description="TF.js NMS: topk per class to keep"
+    )
+    iou_thres: float = Field(default=0.45, description="TF.js NMS: IoU threshold")
+    conf_thres: float = Field(
+        default=0.25, description="TF.js NMS: confidence threshold"
+    )
+    export_samples: int = Field(
+        default=0, description="number of samples to export with onnx"
     )

--- a/src/sparsify/auto/tasks/runner.py
+++ b/src/sparsify/auto/tasks/runner.py
@@ -18,7 +18,6 @@ import json
 import os
 import shutil
 import socket
-import tempfile
 import warnings
 from abc import abstractmethod
 from functools import wraps
@@ -280,13 +279,13 @@ class TaskRunner:
         """
         self.train_hook(**self.train_args.dict())
 
-    def train(self, log_directory: str) -> Metrics:
+    def train(self, train_directory: str, log_directory: str) -> Metrics:
         """
         Training entrypoint
 
         "param log_directory: directory to save logs to
         """
-        self.run_directory = tempfile.TemporaryDirectory()
+        self.run_directory = train_directory
         self.log_directory = log_directory
         self.update_run_directory_args()
 
@@ -389,69 +388,22 @@ class TaskRunner:
             f"memory_stepdown() missing implementation for task {self.task}"
         )
 
-    def move_output(self, target_directory: str, trial_idx: int):
-        """
-        Move output into target directory
-
-        :param target_directory: directory to move output to
-        :param trial_idx: trial index
-        """
-        if not (self.completion_check("train") and self.completion_check("export")):
-            warnings.warn(
-                "Run did not complete successfully. Output generated may not reflect "
-                "a valid run"
-            )
-
-        # move model files to save directory
-        origin_directory = self._get_model_artifact_directory()  # directory to move
-        moved_directory = os.path.join(
-            target_directory, os.path.basename(os.path.normpath(origin_directory))
-        )  # anticipated path to the moved directory, after moving
-
-        # name we want to rename the moved directory to
-        new_directory_name = os.path.join(target_directory, f"trial_{trial_idx}")
-
-        # this should only arise as a result of dev error and not user error
-        if os.path.exists(new_directory_name):
-            raise OSError(f"Directory {new_directory_name} already exists")
-
-        os.makedirs(target_directory, exist_ok=True)
-        shutil.move(origin_directory, target_directory)
-
-        os.rename(
-            moved_directory,
-            new_directory_name,
-        )  # rename directory to one indicating the trial number
-
-        # Clean up run directory
-        self.run_directory.cleanup()
-
     @staticmethod
-    def create_deployment_directory(target_directory: str, trial_idx: int):
+    def create_deployment_directory(train_directory: str, deploy_directory: str):
         """
         Creates and/or moves deployment directory to the deployment directory for the
         mode corresponding to the trial_idx
 
-        :param target_directory: directory to create deployment folder in
-        :param trial_idx: index of the trial to create a deployment directory from
+        :param train_directory: directory to grab the exported files from
+        :param deploy_directory: directory to save the deployment files to
         """
         origin_directory = os.path.join(
-            target_directory,
-            "training",
-            "run_artifacts",
-            "student",
-            f"trial_{trial_idx}",
+            train_directory,
             "deployment",
         )
 
-        # Remove existing deployment directory in the case of a resume run. Note
-        # deployment directory can always be recreated from the run artifacts
-        new_deployment_directory = os.path.join(target_directory, "deployment")
-        if os.path.exists(new_deployment_directory):
-            shutil.rmtree(new_deployment_directory)
-
-        shutil.move(origin_directory, target_directory)
-        with open(os.path.join(target_directory, "deployment", "readme.txt"), "x") as f:
+        shutil.move(origin_directory, deploy_directory)
+        with open(os.path.join(deploy_directory, "deployment", "readme.txt"), "x") as f:
             f.write("deployment instructions will go here")
 
     @abstractmethod

--- a/src/sparsify/auto/tasks/runner.py
+++ b/src/sparsify/auto/tasks/runner.py
@@ -79,8 +79,6 @@ def retry_stage(stage: str):
             # attempt run and catch errors until success or maximum number of attempts
             # exceeded
             while not error_handler.max_attempts_exceeded():
-                out = func(self, *args, **kwargs)
-                break
                 try:
                     out = func(self, *args, **kwargs)
                     exception = None

--- a/src/sparsify/auto/tasks/transformers/args.py
+++ b/src/sparsify/auto/tasks/transformers/args.py
@@ -20,7 +20,7 @@ __all__ = [
     "TransformersExportArgs",
 ]
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import Field
 from sparseml.transformers.text_classification import _TASK_TO_KEYS
@@ -34,8 +34,8 @@ class _TransformersTrainArgs(BaseArgs):
             "huggingface.co/models"
         )
     )
-    distill_teacher: Optional[str] = Field(
-        default=None,
+    distill_teacher: str = Field(
+        default="disable",
         description=("Teacher model which needs to be a trained NER model"),
     )
     config_name: Optional[str] = Field(
@@ -71,8 +71,8 @@ class _TransformersTrainArgs(BaseArgs):
             "https://github.com/neuralmagic/sparseml for more information"
         ),
     )
-    recipe_args: Optional[str] = Field(
-        default=None,
+    recipe_args: Optional[Dict[str, Any]] = Field(
+        default_factory=dict,
         description="Recipe arguments to be overwritten",
     )
     dataset_name: Optional[str] = Field(
@@ -209,8 +209,8 @@ class _TransformersTrainArgs(BaseArgs):
     )
     max_grad_norm: float = Field(default=1.0, description="Max gradient norm.")
 
-    num_train_epochs: Optional[float] = Field(
-        default=None, description="Total number of training epochs to perform."
+    num_train_epochs: float = Field(
+        default=1, description="Total number of training epochs to perform."
     )
     max_steps: int = Field(
         default=-1,

--- a/src/sparsify/auto/utils/helpers.py
+++ b/src/sparsify/auto/utils/helpers.py
@@ -34,7 +34,7 @@ __all__ = [
     "initialize_banner_logger",
 ]
 
-SAVE_DIR = "auto_{{task}}{:_%Y_%m_%d_%H_%M_%S}".format(datetime.now())
+SAVE_DIR = "{{run_mode}}_{{task}}{:_%Y_%m_%d_%H_%M_%S}".format(datetime.now())
 
 
 def initialize_banner_logger():
@@ -53,15 +53,18 @@ def create_save_directory(api_args: "APIArgs") -> Tuple[str]:  # noqa: F821
 
     """
     save_directory = os.path.join(
-        api_args.save_directory, SAVE_DIR.format(task=api_args.task)
+        api_args.save_directory,
+        SAVE_DIR.format(run_mode=api_args.run_mode, task=api_args.task),
     )
-    log_directory = os.path.join(save_directory, "training", "logs")
-    artifact_directory = os.path.join(save_directory, "training", "run_artifacts")
+    train_directory = os.path.join(save_directory, "training_artifacts")
+    log_directory = os.path.join(save_directory, "logs")
+    deploy_directory = os.path.join(save_directory, "deployment")
     os.makedirs(save_directory, exist_ok=True)
+    os.makedirs(train_directory)
     os.makedirs(log_directory)
-    os.makedirs(artifact_directory)
+    os.makedirs(deploy_directory)
 
-    return save_directory, artifact_directory, log_directory
+    return train_directory, log_directory, deploy_directory
 
 
 def save_history(

--- a/src/sparsify/auto/utils/helpers.py
+++ b/src/sparsify/auto/utils/helpers.py
@@ -54,7 +54,7 @@ def create_save_directory(api_args: "APIArgs") -> Tuple[str]:  # noqa: F821
     """
     save_directory = os.path.join(
         api_args.save_directory,
-        SAVE_DIR.format(run_mode=api_args.run_mode, task=api_args.task),
+        SAVE_DIR.format(run_mode=api_args.run_mode.value, task=api_args.task),
     )
     train_directory = os.path.join(save_directory, "training_artifacts")
     log_directory = os.path.join(save_directory, "logs")
@@ -155,7 +155,7 @@ class _BannerFormatter(logging.Formatter):
     bold_red = "\x1b[31;1m"
     reset = "\x1b[0m"
     banner_format = (
-        f"\n{blue}*************************SPARSIFY AUTO**********************{reset}"
+        f"\n{blue}*************************SPARSIFY***************************{reset}"
         "\n%(message)s"
         f"\n{blue}************************************************************\n{reset}"
     )

--- a/src/sparsify/cli/opts.py
+++ b/src/sparsify/cli/opts.py
@@ -150,6 +150,7 @@ OPTIM_LEVEL = click.option(
         "[0, 1]. Default 0.5"
     ),
 )
+TRAIN_KWARGS = click.option("--train-kwargs", default=None, type=str)
 
 
 def add_info_opts(f):
@@ -195,4 +196,9 @@ def add_optim_opts(f):
         OPTIM_LEVEL,
     ]:
         f = fn(f)
+    return f
+
+
+def add_kwarg_opts(f):
+    f = TRAIN_KWARGS(f)
     return f

--- a/src/sparsify/cli/run.py
+++ b/src/sparsify/cli/run.py
@@ -107,14 +107,7 @@ def _parse_run_args_to_auto(sparse_transfer: bool, **kwargs):
         recipe=kwargs["recipe"],
         recipe_args=kwargs["recipe_args"] or {},
         distill_teacher=kwargs["teacher"] or "off",
-        num_trials=1,  # for now, only running 1 trial
-        max_train_time=100000,  # 1 trial, so setting max time arbitrarily high
-        maximum_trial_saves=1,  # 1 trial
-        optimizing_metric=[kwargs["eval_metric"]],
         kwargs={},  # not yet supported
-        teacher_kwargs={},
-        tuning_parameters=None,
-        teacher_tuning_parameters=None,
         run_mode="sparse_transfer" if sparse_transfer else "training_aware",
     )
 

--- a/src/sparsify/cli/run.py
+++ b/src/sparsify/cli/run.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ast
 import json
 from pathlib import Path
 
@@ -100,6 +101,13 @@ def _parse_run_args_to_auto(sparse_transfer: bool, **kwargs):
     if kwargs["eval_metric"] == "kl":
         raise ValueError("--eval-metric kl is not supported currently.")
 
+    recipe_args = (
+        ast.literal_eval(kwargs["recipe_args"]) if kwargs["recipe_args"] else {}
+    )
+    train_kwargs = (
+        ast.literal_eval(kwargs["train_kwargs"]) if kwargs["train_kwargs"] else {}
+    )
+
     return APIArgs(
         task=kwargs["use_case"],
         dataset=kwargs["data"],
@@ -107,9 +115,10 @@ def _parse_run_args_to_auto(sparse_transfer: bool, **kwargs):
         optim_level=kwargs["optim_level"],
         base_model=kwargs["model"],
         recipe=kwargs["recipe"],
-        recipe_args=kwargs["recipe_args"] or {},
+        recipe_args=recipe_args,
         distill_teacher=kwargs["teacher"] or "off",
-        kwargs={kwargs["train_kwargs"]} or {},
+        optimizing_metric=[kwargs["eval_metric"]],
+        kwargs=train_kwargs,
         run_mode="sparse_transfer" if sparse_transfer else "training_aware",
     )
 

--- a/src/sparsify/cli/run.py
+++ b/src/sparsify/cli/run.py
@@ -80,7 +80,7 @@ def sparse_transfer(**kwargs):
 
 @main.command()
 @opts.add_info_opts
-@opts.add_model_opts(require_model=False)
+@opts.add_model_opts(require_model=True)
 @opts.add_data_opts
 @opts.add_deploy_opts
 @opts.add_optim_opts

--- a/src/sparsify/cli/run.py
+++ b/src/sparsify/cli/run.py
@@ -66,6 +66,7 @@ def one_shot(**kwargs):
 @opts.add_data_opts
 @opts.add_deploy_opts
 @opts.add_optim_opts
+@opts.add_kwarg_opts
 def sparse_transfer(**kwargs):
     """
     Run sparse transfer learning for a use case against a supported task and model
@@ -82,6 +83,7 @@ def sparse_transfer(**kwargs):
 @opts.add_data_opts
 @opts.add_deploy_opts
 @opts.add_optim_opts
+@opts.add_kwarg_opts
 def training_aware(**kwargs):
     """
     Run training aware sparsification for a use case against a supported task and model
@@ -107,7 +109,7 @@ def _parse_run_args_to_auto(sparse_transfer: bool, **kwargs):
         recipe=kwargs["recipe"],
         recipe_args=kwargs["recipe_args"] or {},
         distill_teacher=kwargs["teacher"] or "off",
-        kwargs={},  # not yet supported
+        kwargs={kwargs["train_kwargs"]} or {},
         run_mode="sparse_transfer" if sparse_transfer else "training_aware",
     )
 

--- a/src/sparsify/schemas/auto_api.py
+++ b/src/sparsify/schemas/auto_api.py
@@ -28,7 +28,7 @@ import yaml
 
 from pydantic import BaseModel, Field, validator
 from sparsify.schemas import SampledHyperparameter
-from sparsify.utils import DEFAULT_OPTIMIZING_METRIC, METRICS, TASK_REGISTRY
+from sparsify.utils import TASK_REGISTRY
 
 
 __all__ = [
@@ -100,78 +100,10 @@ class APIArgs(BaseModel):
         "base model as teacher",
         default="auto",
     )
-    num_trials: Optional[int] = Field(
-        title="num_trials",
-        description=(
-            "Number of tuning trials to be run before returning best found "
-            "model. Set to None to not impose a trial limit. max_train_time may limit "
-            "the actual num_trials ran"
-        ),
-        default=None,
-    )
-    max_train_time: float = Field(
-        title="max_train_time",
-        description=(
-            "Maximum number of hours to train before returning best trained model."
-        ),
-        default=12.0,
-    )
-    maximum_trial_saves: Optional[int] = Field(
-        title="maximum_trial_saves",
-        description=(
-            "Number of best trials to save on the drive. Items saved for a trial "
-            "include the trained model and associated artifacts. If this value is set "
-            "to n, then at most n+1 models will be saved at any given time on the "
-            "machine. Default value of None allows for unlimited model saving"
-        ),
-        default=None,
-    )
-    no_stopping: bool = Field(
-        title="no_stopping",
-        description=(
-            "Set to True to turn off tuning stopping condition, which may end tuning "
-            "early if no improvement was made"
-        ),
-        default=False,
-    )
-    resume: Optional[str] = Field(
-        title="resume",
-        description=(
-            "To continue a tuning run, provide path to the high level directory of run "
-            "you wish to resume"
-        ),
-        default=None,
-    )
-    optimizing_metric: List[str] = Field(
-        title="optimizing_metric",
-        description=(
-            "The criterion to search model for, multiple metrics can be specified, "
-            "e.g. --optimizing_metric f1 --optimizing_metric latency. Supported  "
-            f"metrics are {METRICS}"
-        ),
-        default=None,
-    )
     kwargs: Optional[Dict[str, Any]] = Field(
         title="kwargs",
         description="optional task specific arguments to add to config",
         default_factory=dict,
-    )
-    teacher_kwargs: Optional[Dict[str, Any]] = Field(
-        title="teacher_kwargs",
-        description="optional task specific arguments to add to teacher config",
-        default_factory=dict,
-    )
-    tuning_parameters: Optional[str] = Field(
-        title="tuning_parameters",
-        description="path to config file containing custom parameter tuning settings. "
-        "See example tuning config output for expected format",
-        default=None,
-    )
-    teacher_tuning_parameters: Optional[str] = Field(
-        title="teacher_tuning_parameters",
-        description="path to config file containing custom teacher parameter tuning "
-        "settings. See example tuning config output for expected format",
-        default=None,
     )
     run_mode: RunMode = Field(
         title="run_mode",
@@ -193,28 +125,6 @@ class APIArgs(BaseModel):
             "their accepted task name aliases:"
             f"{nl.join([task.pretty_print() for task in TASK_REGISTRY.values()])}"
         )
-
-    @validator("tuning_parameters")
-    def read_tuning_parameters_from_file(cls, tuning_parameters: str) -> str:
-        """
-        Read in the tuning parameters as a string for passing to NM API
-        """
-        if tuning_parameters and not tuning_parameters.startswith("-"):
-            with open(tuning_parameters, "r") as file:
-                return file.read()
-        else:
-            return tuning_parameters
-
-    @validator("teacher_tuning_parameters")
-    def read_teacher_tuning_parameters_from_file(cls, tuning_parameters: str) -> str:
-        """
-        Read in the tuning parameters as a string for passing to NM API
-        """
-        if tuning_parameters and not tuning_parameters.startswith("-"):
-            with open(tuning_parameters, "r") as file:
-                return file.read()
-        else:
-            return tuning_parameters
 
     @classmethod
     def from_cli(cls, args: Optional[List[str]] = None):
@@ -267,27 +177,6 @@ class SparsificationTrainingConfig(BaseModel):
         ),
         default=[],
     )
-    optimizing_metric: List[str] = Field(
-        title="optimizing_metric",
-        description=(
-            "The criterion to search model for, multiple metrics can be specified, "
-            "e.g. --optimizing_metric f1 --optimizing_metric latency. Supported  "
-            f"metrics are {METRICS}"
-        ),
-        default=[DEFAULT_OPTIMIZING_METRIC],
-    )
-    no_stopping: bool = Field(
-        title="no_stopping",
-        description=(
-            "Set to True to turn off tuning stopping condition, which may end tuning "
-            "early if no improvement was made"
-        ),
-        default=False,
-    )
-
-    @validator("optimizing_metric")
-    def default_optimizing_metric(cls, optimizing_metric):
-        return optimizing_metric or [DEFAULT_OPTIMIZING_METRIC]
 
     @classmethod
     def from_yaml(cls, config_yaml: str):

--- a/src/sparsify/schemas/auto_api.py
+++ b/src/sparsify/schemas/auto_api.py
@@ -28,7 +28,7 @@ import yaml
 
 from pydantic import BaseModel, Field, validator
 from sparsify.schemas import SampledHyperparameter
-from sparsify.utils import TASK_REGISTRY
+from sparsify.utils import METRICS, TASK_REGISTRY
 
 
 __all__ = [
@@ -99,6 +99,15 @@ class APIArgs(BaseModel):
         "zoo stub, 'off' for no distillation, and default value of 'auto' to auto-tune "
         "base model as teacher",
         default="auto",
+    )
+    optimizing_metric: List[str] = Field(
+        title="optimizing_metric",
+        description=(
+            "The criterion to search model for, multiple metrics can be specified, "
+            "e.g. --optimizing_metric f1 --optimizing_metric latency. Supported  "
+            f"metrics are {METRICS}"
+        ),
+        default=None,
     )
     kwargs: Optional[Dict[str, Any]] = Field(
         title="kwargs",

--- a/src/sparsify/schemas/auto_api.py
+++ b/src/sparsify/schemas/auto_api.py
@@ -108,8 +108,8 @@ class APIArgs(BaseModel):
     run_mode: RunMode = Field(
         title="run_mode",
         description=(
-            "training run mode objective - 'sparse_transfer', 'training_aware', or "
-            "'teacher_only'. Default is 'sparse_transfer'"
+            "training run mode objective - 'sparse_transfer' or 'training_aware'. "
+            "Default is 'sparse_transfer'"
         ),
         default=RunMode.sparse_transfer,
     )


### PR DESCRIPTION
This PR reworks the existing main flow for Auto into a flow that handles Training-Aware Sparse-Transfer runs. As Auto supported multiple hyperparameter tuning and teacher training, it covered quite a lot more cases than the current implementation. As a result, the main function is much simpler than the previous implementation.

This PR also includes updates to integration interfaces needed to sync with latest integration and sparsify changes

**Expected output directory**
```
- save_directory
    - {run_mode}_{task_name}_{date&time}
        - deployment
            - model.onnx
            - readme.txt
            - *other deployment files
        - logs
            - *TensorBoard logs
        - training_artifact
            - *training outputs
        - metrics.yaml
```

**Test Plan**
Tested locally with:

`sparse-transfer --use-case question-answering --data squad --working-dir sparsify-test --train-kwargs "{'max_steps': 10, 'max_eval_samples': 10}"`

`training-aware --use-case question-answering --model bert-base-uncased --data squad --working-dir sparsify-test --train-kwargs "{'max_steps': 10, 'max_eval_samples': 10}"`

`sparse-transfer --use-case object-detection --data /network/datasets/coco1/coco1.yaml --working-dir sparsify-test`

`training-aware --use-case object-detection --data /network/datasets/coco1/coco1.yaml --working-dir sparsify-test --model yolov5s.pt`

`sparse-transfer --use-case image_classification --data /network/datasets/imagenette-160/imagenette-160 --working-dir sparsify-test --train-kwargs "{'max_train_steps': 5,'max_eval_steps': 5}"`