### PR TITLE
Make API KEY an argument for `sparsify.login`

### DIFF
--- a/src/sparsify/login.py
+++ b/src/sparsify/login.py
@@ -13,14 +13,17 @@
 # limitations under the License.
 
 """
-Usage: sparsify.login [OPTIONS]
+Usage: sparsify.login [OPTIONS] API_KEY
 
   sparsify.login utility to log into sparsify locally.
 
+  sparsify.login [API_KEY]
+
+  API_KEY: The API key copied from your sparsify account
+
 Options:
-  --api-key TEXT  API key copied from your account.  [required]
-  --version       Show the version and exit.  [default: False]
-  --help          Show this message and exit.  [default: False]
+  --version  Show the version and exit.  [default: False]
+  --help     Show this message and exit.  [default: False]
 """
 
 import importlib
@@ -56,14 +59,16 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
-@click.option(
-    "--api-key", type=str, help="API key copied from your account.", required=True
-)
+@click.argument("api-key", type=str, required=True)
 @click.version_option(version=version_major_minor)
 @click.option("--debug/--no-debug", default=False, hidden=True)
 def main(api_key: str, debug: bool = False):
     """
     sparsify.login utility to log into sparsify locally.
+
+    sparsify.login [API_KEY]
+
+    API_KEY: The API key copied from your sparsify account
     """
     set_log_level(logger=_LOGGER, level=logging.DEBUG if debug else logging.INFO)
     _LOGGER.info("Logging into sparsify...")


### PR DESCRIPTION
This PR updates api-key to be a required argument for sparsify.login

```bash
sparsify.login --help
Usage: sparsify.login [OPTIONS] API_KEY

  sparsify.login utility to log into sparsify locally.

  sparsify.login [API_KEY]

  API_KEY: The API key copied from your sparsify account

Options:
  --version  Show the version and exit.  [default: False]
  --help     Show this message and exit.  [default: False]
```

Error Message:
```bash
sparsify.login
Usage: sparsify.login [OPTIONS] API_KEY
Try 'sparsify.login --help' for help.

Error: Missing argument 'API_KEY'.
```

Valid Usage with debug: (api key hidden)

```bash
sparsify.login  ********************* --debug
INFO:sparsify.login:Logging into sparsify...
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): accounts.neuralmagic.com:443
DEBUG:urllib3.connectionpool:https://accounts.neuralmagic.com:443 "POST /v1/connect/token HTTP/1.1" 200 3035
INFO:sparsify.utils.helpers:Successfully authenticated with Neural Magic Account API key
INFO:sparsify.login:sparsifyml version 1.5 is already installed, skipping installation from neuralmagic pypi server
DEBUG:sparsify.login:locals: {'api_key': '**********************', 'debug': True}
INFO:sparsify.login:Logged in successfully, sparsify setup is complete.
```