### PR TITLE
Update integration and unit tests

### DIFF
--- a/src/sparsify/auto/tasks/args.py
+++ b/src/sparsify/auto/tasks/args.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel
 
@@ -28,39 +28,65 @@ class BaseArgs(BaseModel):
     def serialize_to_cli_string(self, underscores_to_dashes) -> List[str]:
         """
         Handles logic for converting pydantic classes into valid argument strings.
-        This should set arg standards for all integrations and should generally not
-        be overridden. If the need to override comes up, consider updating this method
-        instead.
 
         :return: string of the full CLI command
         """
         args_string_list = []
         for key, value in self.dict().items():
-            key = "--" + key
             key = key.replace("_", "-") if underscores_to_dashes else key
             # Handles bool type args (e.g. --do-train)
             if isinstance(value, bool):
-                if value:
-                    args_string_list.append(key)
+                bool_str = self._serialize_bool(key, value)
+                if bool_str is not None:
+                    args_string_list.append(bool_str)
             elif isinstance(value, List):
-                if len(value) < 2:
-                    raise ValueError(
-                        "List arguments must have more one entry. "
-                        f"Received {key}:{value}"
-                    )
-                # Handles args that are both bool and value based (see evolve in yolov5)
-                if isinstance(value[0], bool):
-                    if value[0]:
-                        args_string_list.extend([key, str(value[1])])
-                # Handles args that have multiple values after the keyword.
-                # e.g. --freeze-layers 0 10 15
-                else:
-                    args_string_list.append(key)
-                    args_string_list.extend(map(str, value))
+                list_str = self._serialize_list(key, value)
+                if list_str is not None:
+                    args_string_list.extend(list_str)
             # Handles the most straightforward case of keyword followed by value
             # e.g. --epochs 30
             else:
-                if value is None or value == "":
-                    continue
-                args_string_list.extend([key, str(value)])
+                value_str = self._serialize_value(key, value)
+                if value_str is not None:
+                    args_string_list.extend(value_str)
         return args_string_list
+
+    def _serialize_value(self, key: str, value: str) -> Optional[List[str]]:
+        """
+        Handles logic for converting most values to valid argument strings.
+
+        :return: list of serialized strings or None
+        """
+        if value is None or value == "":
+            return None
+        return [f"--{key}", str(value)]
+
+    def _serialize_bool(self, key: str, value: bool) -> Optional[str]:
+        """
+        Handles logic for converting bools to valid argument strings.
+
+        :return: serialized string or None
+        """
+        if value:
+            return "--" + key
+        return None
+
+    def _serialize_list(self, key: str, value: List) -> Optional[List[str]]:
+        """
+        Handles logic for converting lists to valid argument strings.
+
+        :return: list of serialized strings
+        """
+        if len(value) < 2:
+            raise ValueError(
+                "List arguments must have more one entry. " f"Received {key}:{value}"
+            )
+        # Handles args that are both bool and value based (see evolve in yolov5)
+        if isinstance(value[0], bool):
+            if value[0]:
+                return [f"--{key}", str(value[1])]
+            return None
+        # Handles args that have multiple values after the keyword.
+        # e.g. --freeze-layers 0 10 15
+        else:
+            return [f"--{key}", map(str, value)]

--- a/src/sparsify/auto/tasks/image_classification/args.py
+++ b/src/sparsify/auto/tasks/image_classification/args.py
@@ -57,11 +57,11 @@ class _ImageClassificationBaseArgs(BaseArgs):
     )
     pretrained: str = Field(default="True", description="type of pretrained weights")
     pretrained_dataset: str = Field(default=None, description="checkpoint data name")
-    model_kwargs: str = Field(
-        default=dict(), description="json string for model constructor args"
+    model_kwargs: Optional[Dict[str, Any]] = Field(
+        default_factory=dict, description="json string for model constructor args"
     )
-    dataset_kwargs: str = Field(
-        default=dict(), description="json string for dataset constructor args"
+    dataset_kwargs: Optional[Dict[str, Any]] = Field(
+        default_factory=dict, description="json string for dataset constructor args"
     )
     model_tag: str = Field(description="required - tag for model under save_dir")
     save_dir: Union[str, Path] = Field(default=ROOT)

--- a/src/sparsify/auto/tasks/runner.py
+++ b/src/sparsify/auto/tasks/runner.py
@@ -79,8 +79,8 @@ def retry_stage(stage: str):
             # attempt run and catch errors until success or maximum number of attempts
             # exceeded
             while not error_handler.max_attempts_exceeded():
+                out = func(self, *args, **kwargs)
                 try:
-                    out = func(self, *args, **kwargs)
                     exception = None
                 except Exception as e:
                     exception = e

--- a/src/sparsify/auto/tasks/transformers/args.py
+++ b/src/sparsify/auto/tasks/transformers/args.py
@@ -554,6 +554,20 @@ class QuestionAnsweringArgs(_TransformersTrainArgs):
         ),
     )
 
+    def _serialize_bool(self, key: str, value: bool) -> Optional[str]:
+        """
+        Handles logic for converting bools to valid argument strings.
+
+        :return: serialized string or None
+        """
+        # Fields that default to true on the integration side and should be appended
+        # with `--no_` if false
+        _HF_TRUE_DEFAULTS = ["pad_to_max_length"]
+        if key in _HF_TRUE_DEFAULTS:
+            return "--no_" + key if value is False else None
+
+        return super(QuestionAnsweringArgs, self)._serialize_bool(key, value)
+
 
 class TextClassificationArgs(_TransformersTrainArgs):
     max_predict_samples: Optional[int] = Field(
@@ -569,18 +583,26 @@ class TextClassificationArgs(_TransformersTrainArgs):
             "The name of the task to train on: " + ", ".join(_TASK_TO_KEYS.keys())
         ),
     )
-    text_column_name: Optional[str] = Field(
-        default=None,
-        description=(
-            "The column name of text to input in the file " "(a csv or JSON file)."
-        ),
-    )
     label_column_name: Optional[str] = Field(
-        default=None,
+        default="label",
         description=(
             "The column name of label to input in the file " "(a csv or JSON file)."
         ),
     )
+
+    def _serialize_bool(self, key: str, value: bool) -> Optional[str]:
+        """
+        Handles logic for converting bools to valid argument strings.
+
+        :return: serialized string or None
+        """
+        # Fields that default to true on the integration side and should be appended
+        # with `--no_` if false
+        _HF_TRUE_DEFAULTS = ["pad_to_max_length"]
+        if key in _HF_TRUE_DEFAULTS:
+            return "--no_" + key if value is False else None
+
+        return super(TextClassificationArgs, self)._serialize_bool(key, value)
 
 
 class TokenClassificationArgs(_TransformersTrainArgs):

--- a/tests/integration/auto/test_cli_run.py
+++ b/tests/integration/auto/test_cli_run.py
@@ -166,7 +166,7 @@ _EXTENSIVE_TESTING_ENABLED = os.environ.get(
                 "--use-case",
                 "image_classification",
                 "--model",
-                "zoo:cv/classification/mobilenet_v2-1.0/pytorch/sparseml/imagenet/base-none",  # noqa: E501
+                "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative",  # noqa: E501
                 "--data",
                 "imagenette",
                 "--train-kwargs",

--- a/tests/sparsify/utils/test_task_name.py
+++ b/tests/sparsify/utils/test_task_name.py
@@ -26,7 +26,7 @@ from sparsify.utils import TASK_REGISTRY, TaskName
             "cv",
             "classification",
             ["Image-Classification", "ic", "IC", "classification", "CLASSIFICATION"],
-            ["image classification", "imageclassification"],
+            ["cv"],
         ),
         (
             "object_detection",
@@ -40,7 +40,7 @@ from sparsify.utils import TASK_REGISTRY, TaskName
                 "detection",
                 "DETECTION",
             ],
-            ["object detection", "objectdetection"],
+            ["yolo"],
         ),
         (
             "segmentation",
@@ -51,7 +51,7 @@ from sparsify.utils import TASK_REGISTRY, TaskName
                 "Segmentation",
                 "SEGMENTATION",
             ],
-            ["object_segmentation"],
+            ["object-segmentation"],
         ),
         (
             "question_answering",
@@ -63,7 +63,7 @@ from sparsify.utils import TASK_REGISTRY, TaskName
                 "qa",
                 "QA",
             ],
-            ["question answering", "questionanswering"],
+            ["questionanswer"],
         ),
         (
             "text_classification",
@@ -75,7 +75,7 @@ from sparsify.utils import TASK_REGISTRY, TaskName
                 "glue",
                 "GLUE",
             ],
-            ["text classification", "textclassification"],
+            ["text"],
         ),
         (
             "sentiment_analysis",
@@ -87,7 +87,7 @@ from sparsify.utils import TASK_REGISTRY, TaskName
                 "sentiment",
                 "SENTIMENT",
             ],
-            ["sentiment analysis", "sentimentanalysis"],
+            ["imdb"],
         ),
         (
             "token_classification",
@@ -95,7 +95,7 @@ from sparsify.utils import TASK_REGISTRY, TaskName
             "nlp",
             "token_classification",
             ["Token-Classification", "ner", "NER", "Named-Entity-Recognition"],
-            ["token classification", "tokenclassification"],
+            ["token"],
         ),
     ],
 )


### PR DESCRIPTION
This PR mainly targets integration tests and updates them to the latest rework for training-aware and sparse-transfer. It also updates the few failing unit tests. 

There are 10 tests, 2 for each use case to cover sparse-transfer and transfer-aware modes. By default, only 3 tests are run (one QA, one OD, and one IC) when setting off integration tests. To set off the full suite of tests, env variable `SPARSIFY_EXTENSIVE_INTEGRATION_TEST` needs to be set to True

**Test Plan**
`SPARSIFY_EXTENSIVE_INTEGRATION_TEST=1 make test_integration`