### PR TITLE
Add login step to test setup

### DIFF
--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -41,6 +41,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: "⚙️ Install dependencies"
         run: pip3 install -e .[dev]
+      - name: "⚙️ Logging into Sparsify"
+        run: sparsify.login ${{ secrets.NM_SPARSIFY_TEST_API_KEY }}
       - name: "🔬 Running base tests"
         run: make test
       - name: "🔬 Running package tests"


### PR DESCRIPTION
This PR adds a `Sparsify.login` step to the test workflow, which is now required to run any Sparsify code