### PR TITLE
Add automatic PR integration tests

### DIFF
--- a/.github/workflows/integrations-check.yaml
+++ b/.github/workflows/integrations-check.yaml
@@ -22,5 +22,5 @@ jobs:
     - name: "⚙️ Logging into Sparsify"
       run: sparsify.login ${{ secrets.NM_SPARSIFY_TEST_API_KEY }}
     - name: "🔬 Running integrations tests (pre-commit)"
-      run: make test_integration
+      run: make test_integration TARGETS=auto
 

--- a/.github/workflows/integrations-check.yaml
+++ b/.github/workflows/integrations-check.yaml
@@ -1,0 +1,41 @@
+name: Integrations Testing
+on: 
+  pull_request:
+    branches:
+      - sparsify.alpha
+      - main
+      - 'release/*'
+
+jobs:
+  test-setup:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: git branch --show-current
+      - name: Get current branch
+        id: get-branch
+        run: >
+          (git branch --show-current | grep -E "release/")
+          && echo "::set-output name=branch::$(git branch --show-current)"
+          || echo "::set-output name=branch::main"
+  integrations-tests:
+    runs-on: ubuntu-22.04
+    needs: test-setup
+    env:
+      SPARSEZOO_TEST_MODE: "true"
+      SPARSIFY_EXTENSIVE_INTEGRATION_TEST: ""
+    steps:
+      steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - uses: actions/checkout@v2
+      - name: "⚙️ Install dependencies"
+        run: pip3 install -e .[dev]
+      - name: "⚙️ Logging into Sparsify"
+        run: sparsify.login ${{ secrets.NM_SPARSIFY_TEST_API_KEY }}
+      - name: "🔬 Running integrations tests (pre-commit}})"
+        run: make test_integration
+

--- a/.github/workflows/integrations-check.yaml
+++ b/.github/workflows/integrations-check.yaml
@@ -2,40 +2,25 @@ name: Integrations Testing
 on: 
   pull_request:
     branches:
-      - sparsify.alpha
+      - sparsify.alpha # TODO: delete after merge
       - main
       - 'release/*'
 
 jobs:
-  test-setup:
+  integrations-test:
     runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - run: git branch --show-current
-      - name: Get current branch
-        id: get-branch
-        run: >
-          (git branch --show-current | grep -E "release/")
-          && echo "::set-output name=branch::$(git branch --show-current)"
-          || echo "::set-output name=branch::main"
-  integrations-tests:
-    runs-on: ubuntu-22.04
-    needs: test-setup
     env:
       SPARSEZOO_TEST_MODE: "true"
       SPARSIFY_EXTENSIVE_INTEGRATION_TEST: ""
     steps:
-      steps:
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - uses: actions/checkout@v2
-      - name: "⚙️ Install dependencies"
-        run: pip3 install -e .[dev]
-      - name: "⚙️ Logging into Sparsify"
-        run: sparsify.login ${{ secrets.NM_SPARSIFY_TEST_API_KEY }}
-      - name: "🔬 Running integrations tests (pre-commit}})"
-        run: make test_integration
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - uses: actions/checkout@v2
+    - name: "⚙️ Install dependencies"
+      run: pip3 install -e .[dev]
+    - name: "⚙️ Logging into Sparsify"
+      run: sparsify.login ${{ secrets.NM_SPARSIFY_TEST_API_KEY }}
+    - name: "🔬 Running integrations tests (pre-commit)"
+      run: make test_integration
 

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,6 @@ ifneq ($(findstring auto,$(TARGETS)),auto)
     PYTEST_ARGS := $(PYTEST_ARGS) --ignore tests/sparsify/auto
 	INTEGRATION_TEST_ARGS := $(INTEGRATION_TEST_ARGS) --ignore tests/integration/auto
 endif
-ifneq ($(findstring package,$(TARGETS)),package)
-    PYTEST_ARGS := $(PYTEST_ARGS) --ignore tests/sparsify/package
-	INTEGRATION_TEST_ARGS := $(INTEGRATION_TEST_ARGS) --ignore tests/integration/package
-endif
 
 # run checks on all files for the repo
 quality:

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test:
 # run end to end integration tests
 test_integration:
 	@echo "Running integration tests";
-	SPARSEZOO_TEST_MODE="true" pytest tests/integration  --ignore tests/sparsify $(INTEGRATION_TEST_ARGS);
+	SPARSEZOO_TEST_MODE="true" pytest -ls tests/integration  --ignore tests/sparsify $(INTEGRATION_TEST_ARGS);
 
 # create docs
 docs:

--- a/src/sparsify/auto/tasks/object_detection/yolov5/args.py
+++ b/src/sparsify/auto/tasks/object_detection/yolov5/args.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pydantic import Field
 from sparsify.auto.tasks import BaseArgs
@@ -86,6 +86,10 @@ class _Yolov5BaseTrainArgs(BaseArgs):
         default=None,
         description="Path to a sparsification recipe, "
         "see https://github.com/neuralmagic/sparseml for more information",
+    )
+    recipe_args: Optional[Dict[str, Any]] = Field(
+        default_factory=dict,
+        description="Recipe arguments to be overwritten",
     )
     upload_dataset: bool = Field(
         default=False, description='W&B: Upload data, "val" option'

--- a/src/sparsify/auto/tasks/runner.py
+++ b/src/sparsify/auto/tasks/runner.py
@@ -41,7 +41,9 @@ __all__ = [
     "TaskRunner",
 ]
 
-DDP_ENABLED = not (os.environ.get("NM_AUTO_DISABLE_DDP", False))
+DDP_ENABLED = (
+    not (os.environ.get("NM_AUTO_DISABLE_DDP", False)) and torch.cuda.is_available()
+)
 MAX_RETRY_ATTEMPTS = os.environ.get("NM_MAX_SCRIPT_RETRY_ATTEMPTS", 3)  # default: 3
 MAX_MEMORY_STEPDOWNS = os.environ.get("NM_MAX_SCRIPT_MEMORY_STEPDOWNS", 10)
 SUPPORTED_TASKS = [

--- a/tests/integration/auto/test_cli_run.py
+++ b/tests/integration/auto/test_cli_run.py
@@ -157,7 +157,7 @@ _EXTENSIVE_TESTING_ENABLED = os.environ.get(
                 "--data",
                 "imagenette",
                 "--train-kwargs",
-                "{'max_train_steps': 5,'max_eval_steps': 5}",
+                "{'max_train_steps': 5,'max_eval_steps': 5, 'train_batch_size': 4, 'test_batch_size': 4}",  # noqa: E501
             ],
             False,
         ),

--- a/tests/integration/auto/test_cli_run.py
+++ b/tests/integration/auto/test_cli_run.py
@@ -142,7 +142,7 @@ _EXTENSIVE_TESTING_ENABLED = os.environ.get(
                 "--model",
                 "yolov5s.pt",
                 "--train-kwargs",
-                "{'max_steps': 10}",
+                "{'max_steps': 10, 'batch_size': 1, 'imgsz': 160}",
                 "--recipe-args",
                 "{'num_epochs': 2, 'num_qat_epochs': 1, 'num_qat_finetuning_epochs': 0, 'num_pruning_active_epochs': 1, 'num_pruning_finetuning_epochs': 0}",  # noqa: E501
             ],

--- a/tests/integration/auto/test_cli_run.py
+++ b/tests/integration/auto/test_cli_run.py
@@ -140,7 +140,7 @@ _EXTENSIVE_TESTING_ENABLED = os.environ.get(
                 "--data",
                 "coco128.yaml",
                 "--model",
-                "yolov5s.pt",
+                "yolov5n.pt",
                 "--train-kwargs",
                 "{'max_steps': 10, 'batch_size': 1, 'imgsz': 160}",
                 "--recipe-args",

--- a/tests/integration/auto/test_cli_run.py
+++ b/tests/integration/auto/test_cli_run.py
@@ -179,7 +179,7 @@ _EXTENSIVE_TESTING_ENABLED = os.environ.get(
 @pytest.mark.skipif(
     not _SPARSIFYML_INSTALLED, reason="`sparsifyml` needed to run local tests"
 )
-def test_output(task, command, extensive):
+def test_integration_output(task, command, extensive):
     if extensive and not _EXTENSIVE_TESTING_ENABLED:
         pytest.skip(
             "To enable all integration tests, set "

--- a/tests/integration/auto/test_cli_run.py
+++ b/tests/integration/auto/test_cli_run.py
@@ -27,7 +27,7 @@ from sparsify.utils import TASK_REGISTRY
 _OUTPUT_DIRECTORY = "sparsify_training_temp_integration_test"
 _SPARSIFYML_INSTALLED: bool = importlib.util.find_spec("sparsifyml") is not None
 _EXTENSIVE_TESTING_ENABLED = os.environ.get(
-    "SPARSIFY_EXTENSIVE_INTEGRATION_TEST", True  # TODO: remove
+    "SPARSIFY_EXTENSIVE_INTEGRATION_TEST", False
 )
 
 
@@ -143,6 +143,8 @@ _EXTENSIVE_TESTING_ENABLED = os.environ.get(
                 "yolov5s.pt",
                 "--train-kwargs",
                 "{'max_steps': 10}",
+                "--recipe-args",
+                "{'num_epochs': 2, 'num_qat_epochs': 1, 'num_qat_finetuning_epochs': 0, 'num_pruning_active_epochs': 1, 'num_pruning_finetuning_epochs': 0}",  # noqa: E501
             ],
             False,
         ),


### PR DESCRIPTION
This PR adds a workflow which triggers the base integration tests (3 out of the 10 total case) when a PR is opened against `sparsify.alpha` (to be changed to `main` later).

In the near future, may add a PR which triggers the rest of the tests after a PR lands