### PR TITLE
[Cherry-Pick] Update version sparsify beta 1.6.0

### DIFF
--- a/src/sparsify/version.py
+++ b/src/sparsify/version.py
@@ -19,7 +19,7 @@ Functionality for storing and setting the version info for Sparsify
 from datetime import date
 
 
-version_base = "1.5.0"
+version_base = "1.6.0"
 is_release = False  # change to True to set the generated version as a release version
 
 


### PR DESCRIPTION
Updates the version of sparsify.beta branch to 1.6 to allow installing latest versions of sparsezoo, sparseml and deepsparse