### PR TITLE
[BugFix] Pin Protobuff Dependecies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ _deps = [
     "setuptools>=56.0.0",
     "optuna>=3.0.2",
     "onnxruntime-gpu",
+    "protobuf<=3.20.1,>=3.12.2",
 ]
 _nm_deps = [
     f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_nm_deps}",


### PR DESCRIPTION
When installing from `sparsify.alpha` the installed protobuff versions can mismatch what is needed by our other repos.

This PR fixes that by explicitly setting the version in `setup.py`

## Test

```bash
pip install -e .
sparsify.login XXXAPI-KEYXXX
sparsify.run one-shot \
    --use-case image_classification \
    --model ~/models/resnet-pruned-conservatove.onnx \
    --data /network/datasets/imagenette-160/imagenette-160 \
    --working-dir ./one-shot-test
```

Output:
```bash
Calibration: 501it [02:52,  2.91it/s]                                                                                                                                                                
Compressing Conv_7: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 344.10it/s]
Compressing Conv_20: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 36/36 [00:00<00:00, 358.39it/s]
Compressing Conv_22: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 278.31it/s]
Compressing Conv_25: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 16/16 [00:00<00:00, 371.09it/s]
Compressing Conv_30: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 16/16 [00:00<00:00, 369.03it/s]
Compressing Conv_27: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 72/72 [00:00<00:00, 350.70it/s]
Compressing Conv_29: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:00<00:00, 321.28it/s]
Compressing Conv_33: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 32/32 [00:00<00:00, 363.61it/s]
Compressing Conv_35:   0%|                                                                                                                                                    | 0/72 [00:00<?, ?it/s]H inversion failed with original dampening fraction of 0.001. It eventually successed with dampening fraction of 0.01
Compressing Conv_13: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 36/36 [00:00<00:00, 101.50it/s]
Compressing Conv_37: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:00<00:00, 92.07it/s]
Compressing Conv_35:  86%|██████████████████████████████████
```

Noting: Installed Cuda and CuDNN versions

```
CUDA: 11.6
CuDNN: 8.5.0
onnxruntime-gpu: 1.15.0
python: 3.8.12

```
