### PR TITLE
Update GHA file for auto tests

### DIFF
--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -48,4 +48,4 @@ jobs:
       - name: "🔬 Running package tests"
         run: make test TARGETS=package
       - name: "🔬 Running auto tests"
-        run: pip install sparseml[yolov5] && make test TARGETS=auto
+        run: pip install sparseml-nightly[yolov5] && make test TARGETS=auto


### PR DESCRIPTION
Currently GHA installs `sparseml[yolov5]` for running auto tests, this can lead to an older install of sparsezoo/sparseml packages and cause errors in tests like the following:

https://github.com/neuralmagic/sparsify/actions/runs/5326675996/jobs/9649024641?pr=213

in this case sparsezoo-nightly~=1.6 was downgraded to `sparsezoo~=1.5` which does not have the relevant bugfixes.

Proposed PR fixes that by using sparseml-nightly for auto tests
After rebasing on this PR the tests pass: https://github.com/neuralmagic/sparsify/actions/runs/5335310317/jobs/9668344241?pr=213