### PR TITLE
Add environment checks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ def _setup_entry_points() -> Dict:
         "console_scripts": [
             "sparsify.run=sparsify.cli.run:main",
             "sparsify.login=sparsify.login:main",
+            "sparsify.check_environment=sparsify.check_environment.main:main",
         ]
     }
 

--- a/src/sparsify/check_environment/__init__.py
+++ b/src/sparsify/check_environment/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# flake8: noqa
+# isort: skip_file
+
+from .gpu_device import *
+from .ort_health import *
+from .pathway_checks import *

--- a/src/sparsify/check_environment/gpu_device.py
+++ b/src/sparsify/check_environment/gpu_device.py
@@ -30,7 +30,7 @@ def check_for_gpu():
     if not torch.cuda.is_available():
         _LOGGER.warn(
             "*************************** NO GPU DETECTED ***************************\n"
-            "No GPU detected on machine. The use of a GPU for training-aware "
+            "No GPU(s) detected on machine. The use of a GPU for training-aware "
             "sparsification, sparse-transfer learning, and one-shot sparsification is "
             "highly recommended.\n"
             "************************************************************************"

--- a/src/sparsify/check_environment/gpu_device.py
+++ b/src/sparsify/check_environment/gpu_device.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+
+
+_LOGGER = logging.getLogger(__name__)
+
+__all__ = ["check_for_gpu"]
+
+
+def check_for_gpu():
+    """
+    Check for GPU and warn if not found
+    """
+    _LOGGER.warning("Checking for GPU...")
+    if not torch.cuda.is_available():
+        _LOGGER.warn(
+            "*************************** NO GPU DETECTED ***************************\n"
+            "No GPU detected on machine. The use of a GPU for training-aware "
+            "sparsification, sparse-transfer learning, and one-shot sparsification is "
+            "highly recommended.\n"
+            "************************************************************************"
+        )
+    else:
+        _LOGGER.warning("GPU check completed successfully")

--- a/src/sparsify/check_environment/main.py
+++ b/src/sparsify/check_environment/main.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from sparsify.check_environment import check_for_gpu, check_ort_health
+
+
+def main():
+    """
+    Check the environment for compatibility with the sparsifyml package
+    """
+    check_for_gpu()
+    check_ort_health()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sparsify/check_environment/ort_health.py
+++ b/src/sparsify/check_environment/ort_health.py
@@ -135,7 +135,7 @@ def check_ort_health(providers: Optional[List[str]] = None):
             input_batch=random_input,
             providers=providers,
         )
-    except RuntimeError as e:
+    except Exception as e:
         # If run fails, try again with CPU only to ensure this is a CUDA environment
         # issue
         if providers != ["CPUExecutionProvider"]:

--- a/src/sparsify/check_environment/ort_health.py
+++ b/src/sparsify/check_environment/ort_health.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import logging
+from typing import List, Optional
+
+import numpy
+import torch
+from onnx import TensorProto, helper
+
+import onnxruntime as ort
+from deepsparse.utils import generate_random_inputs, get_input_names
+from sparsifyml.one_shot.utils import run_onnx_model
+
+
+__all__ = ["check_ort_health"]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+CUDA_HELP_STRING = (
+    "If you would like to run on GPU, please ensure that your CUDA and cuDNN "
+    "versions are compatible with the installed version of onnxruntime-gpu: "
+    "https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements"  # noqa: E501
+)
+
+
+def _create_simple_conv_graph(
+    image_pixels_side: int = 32,
+    channel_count: int = 3,
+    batch_size: int = 1,
+    kernel_size: int = 3,
+    kernel_count: int = 10,
+):
+    feature_size_side = image_pixels_side - kernel_size + 1
+
+    # The inputs and outputs
+    X = helper.make_tensor_value_info(
+        "X",
+        TensorProto.FLOAT,
+        [batch_size, channel_count, image_pixels_side, image_pixels_side],
+    )
+    Y = helper.make_tensor_value_info(
+        "Y",
+        TensorProto.FLOAT,
+        [batch_size, kernel_count, feature_size_side, feature_size_side],
+    )
+
+    # Create nodes for Conv, Relu, Flatten, and Gemm (Fully Connected) operations
+    conv_node = helper.make_node(
+        "Conv",
+        inputs=["X", "conv_weight", "conv_bias"],
+        outputs=["conv_result"],
+        kernel_shape=[kernel_size, kernel_size],
+    )
+
+    relu_node1 = helper.make_node(
+        "Relu",
+        inputs=["conv_result"],
+        outputs=["Y"],
+    )
+
+    # Define the weights for the Conv and Gemm layers
+    conv_weight = helper.make_tensor(
+        "conv_weight",
+        TensorProto.FLOAT,
+        [kernel_count, channel_count, kernel_size, kernel_size],
+        numpy.random.randn(kernel_count, channel_count, kernel_size, kernel_size),
+    )
+    conv_bias = helper.make_tensor(
+        "conv_bias", TensorProto.FLOAT, [kernel_count], numpy.random.randn(kernel_count)
+    )
+
+    # Create the graph (model)
+
+    graph_def = helper.make_graph(
+        [conv_node, relu_node1],
+        "SimpleCNN",
+        inputs=[X],
+        outputs=[Y],
+        initializer=[conv_weight, conv_bias],
+    )
+
+    return helper.make_model(graph_def, producer_name="onnx-example")
+
+
+def check_ort_health(providers: Optional[List[str]] = None):
+    """
+    Checks that the model can be executed with the set providers
+
+    :param model: model to check
+    :param providers: list of providers use for ORT execution
+    """
+    _LOGGER.warning("Checking onnxruntime-gpu environment health...")
+
+    model = _create_simple_conv_graph()
+
+    providers = (
+        ["CUDAExecutionProvider"]
+        if torch.cuda.is_available()
+        else ["CPUExecutionProvider"]
+    )
+
+    # If cuda device found by torch, ensure it's found by ORT as well
+    if ort.get_device() != "GPU" and "CUDAExecutionProvider" in providers:
+        raise RuntimeError(
+            "CUDA enabled device detected on your machine, but is not detected by "
+            "onnxruntime. If you would like to run on CPU, please set "
+            "CUDA_VISIBLE_DEVICES=-1. Note that this is likely to slow down model "
+            f"compression significantly. {CUDA_HELP_STRING}"
+        )
+
+    # Ensure that ORT can execute the model
+    random_input = {
+        input_name: input
+        for input_name, input in zip(
+            get_input_names(model), generate_random_inputs(model)
+        )
+    }
+    try:
+        run_onnx_model(
+            model=model,
+            input_batch=random_input,
+            providers=providers,
+        )
+    except RuntimeError as e:
+        # If run fails, try again with CPU only to ensure this is a CUDA environment
+        # issue
+        if providers != ["CPUExecutionProvider"]:
+            try:
+                run_onnx_model(
+                    model=model,
+                    input_batch=random_input,
+                    providers=["CPUExecutionProvider"],
+                )
+
+                raise RuntimeError(
+                    "ONNXRuntime execution failed with CUDAExecutionProvider"
+                    "but succeeded with CPUExecutionProvider. This is indicative"
+                    f"of a likely issue with nnxruntime-gpu install {CUDA_HELP_STRING}"
+                ) from e
+
+            except RuntimeError:
+                pass
+
+        raise RuntimeError(
+            "ONNXRuntime execution failed with both CUDAExecutionProvider and "
+            "CPUExecutionProvider. Ensure that onnxruntime-gpu and its dependencies "
+            "are properly installed."
+        ) from e
+
+    _LOGGER.warning("Onnxruntime-gpu environment check completed successfully")

--- a/src/sparsify/check_environment/ort_health.py
+++ b/src/sparsify/check_environment/ort_health.py
@@ -161,4 +161,4 @@ def check_ort_health(providers: Optional[List[str]] = None):
             "are properly installed."
         ) from e
 
-    _LOGGER.warning("Onnxruntime-gpu environment check completed successfully")
+    _LOGGER.warning("onnxruntime-gpu environment check completed successfully")

--- a/src/sparsify/check_environment/pathway_checks.py
+++ b/src/sparsify/check_environment/pathway_checks.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from sparsify.check_environment import check_for_gpu, check_ort_health
+
+
+__all__ = ["one_shot_checks", "auto_checks"]
+
+
+def one_shot_checks():
+    """
+    Check environment for compatibility with one-shot sparsification
+    """
+    check_for_gpu()
+    check_ort_health()
+
+
+def auto_checks():
+    """
+    Check environment for compatibility with training-aware sparsification and
+    sparse-transfer learning
+    """
+    check_for_gpu()

--- a/src/sparsify/cli/run.py
+++ b/src/sparsify/cli/run.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import click
 from sparsezoo import Model
+from sparsify.check_environment import auto_checks, one_shot_checks
 from sparsify.cli import opts
 
 
@@ -44,6 +45,8 @@ def one_shot(**kwargs):
     """
     # raises exception if sparsifyml not installed
     from sparsify.one_shot import one_shot
+
+    one_shot_checks()
 
     recipe_args = kwargs.get("recipe_args")
     if isinstance(recipe_args, str):
@@ -75,6 +78,8 @@ def sparse_transfer(**kwargs):
     """
     from sparsify import auto
 
+    auto_checks()
+
     # recipe arg should be a sparse transfer recipe
     auto.main(_parse_run_args_to_auto(sparse_transfer=True, **kwargs))
 
@@ -91,6 +96,8 @@ def training_aware(**kwargs):
     Run training aware sparsification for a use case against a supported task and model
     """
     from sparsify import auto
+
+    auto_checks()
 
     # recipe arg should be a training aware recipe
     auto.main(_parse_run_args_to_auto(sparse_transfer=False, **kwargs))


### PR DESCRIPTION
This PR adds environment checks that will help detect a broken sparsify environment before a run is fully launched. There are three pathways by which environment checks are launched:

- The CLI command `sparsify.check_environment` will run all health checks
- Running an experiment with `sparsify.run training-aware` or `sparsify.run sparse-transfer` will run health checks relevant to these two pathways
- Running an experiment with `sparsify.run one-shot` will run the health checks relevant to one-shot

Currently implemented health checks
GPU device check - this is a non-failing check, but it will raise a loud error
ORT health check - this is a failing check which will point the user to the ORT-GPU dependency matrix

**Test Plan**

- [x] `sparsify.check_environment`
- [x] `CUDA_VISIBLE_DEVICES="" sparsify.check_environment`
- [x] `sparsify.run training-aware --use-case image-classification --model mobilenet-v1 --data /network/datasets/imagenet --optim-level 0`
- [x] `sparsify.run  one-shot  --model model.onnx  --data coco_calibration  --use-case cv-detection  --optim-level 0.5`
- [x] Test on system with broken ORT-GPU environment
