### PR TITLE
Clean GHA files post merge

### DIFF
--- a/.github/workflows/quality-check.yaml
+++ b/.github/workflows/quality-check.yaml
@@ -12,6 +12,13 @@ jobs:
   quality-check:
     runs-on: ubuntu-latest
     steps:
+      - name: "Python Version"
+        run: python3 --version
+
+      - name: "Upgrade pip and output version"
+        run: |
+          python3 -m pip install --upgrade pip
+          pip3 --version
       - uses: actions/checkout@v2
       - uses: actions/checkout@v2
         with:
@@ -29,12 +36,7 @@ jobs:
         run: pip3 install sparseml/
       - name: "Clean sparseml directory"
         run: rm -r sparseml/
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14'
       - name: "⚙️ Install python dependencies"
         run: pip3 install .[dev]
-      - name: "⚙️ Install yarn dependencies"
-        run: yarn install
       - name: "🧹 Running quality checks"
         run: make quality

--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -20,7 +20,6 @@ jobs:
           fetch-depth: 0
       - name: "Checking if sparsify python code was changed"
         id: python-check
-        # TODO: delete sparsify.alpha reference after merge
         run: >
           ((git diff --name-only origin/main HEAD | grep -E "[src|tests]/sparsify|setup.py")
           || (echo $GITHUB_REF | grep -E "refs/heads/[release/|main]"))


### PR DESCRIPTION
Pip 22.0 and 22.0.1 give AssertionError when trying to resolve dependencies; --upgrade pip in GHA is recommended before running tests

This PR also cleans up GHA files for sparsify

Issue on PyPa: https://github.com/pypa/pip/issues/10851
