### PR TITLE
[BUG] Update `DDP_ENABLED` flag

### DIFF
--- a/src/sparsify/auto/tasks/runner.py
+++ b/src/sparsify/auto/tasks/runner.py
@@ -41,7 +41,9 @@ __all__ = [
     "TaskRunner",
 ]
 
-DDP_ENABLED = not (os.environ.get("NM_AUTO_DISABLE_DDP", False))
+DDP_ENABLED = (
+    not (os.environ.get("NM_AUTO_DISABLE_DDP", False)) and torch.cuda.is_available()
+)
 MAX_RETRY_ATTEMPTS = os.environ.get("NM_MAX_SCRIPT_RETRY_ATTEMPTS", 3)  # default: 3
 MAX_MEMORY_STEPDOWNS = os.environ.get("NM_MAX_SCRIPT_MEMORY_STEPDOWNS", 10)
 SUPPORTED_TASKS = [


### PR DESCRIPTION
### Summary:

For this ticket - https://app.asana.com/0/1204777926187571/1204947833549381/f

We want to only enable DDP if cuda/gpus are available. Ticket relates to the way `WORLD_SIZE` is set by pytorch during cpu distributed training.
