### PR TITLE
Parse out the `data` arg for transformer workflows to populate train/test/validation kwargs

### DIFF
--- a/src/sparsify/auto/tasks/transformers/runner.py
+++ b/src/sparsify/auto/tasks/transformers/runner.py
@@ -99,7 +99,7 @@ class _TransformersRunner(TaskRunner):
         overwritten if directory is provided.
 
         :params dataset: inputted data string arg. Assumed to either be a dataset which
-        can be downloaded publically or a locally available directory containing
+        can be downloaded publicly or a locally available directory containing
         data files.
 
         :returns: updated dataset, train_file, test_file, and validation_file args

--- a/src/sparsify/auto/tasks/transformers/runner.py
+++ b/src/sparsify/auto/tasks/transformers/runner.py
@@ -97,7 +97,8 @@ class _TransformersRunner(TaskRunner):
         test and validation file arguments with the approriate filepaths. This function
         assumes any file containing the substrings "train", "test", or "val" are the
         data files expected to be used. Duplicates will be updated to only use one file
-        path.
+        path. Also, existing kwargs for train, test and validation files will be
+        overwritten if directory is provided.
 
         :params dataset: inputted data string arg. Assumed to either be a dataset which
         can be downloaded publically or a locally available directory containing

--- a/src/sparsify/auto/tasks/transformers/runner.py
+++ b/src/sparsify/auto/tasks/transformers/runner.py
@@ -16,7 +16,7 @@ import json
 import math
 import os
 import re
-from typing import Dict, Tuple, Union
+from typing import Tuple, Union
 
 import onnx
 
@@ -89,9 +89,7 @@ class _TransformersRunner(TaskRunner):
         return train_args, export_args
 
     @classmethod
-    def parse_data_args(
-        cls, dataset: str
-    ) -> Tuple[Union[str, None], Dict[str : Union[str, None]]]:
+    def parse_data_args(cls, dataset: str) -> Tuple[Union[str, None], dict]:
         """
         Check if the dataset provided is a data directory. If it is, update the train,
         test and validation file arguments with the approriate filepaths. This function
@@ -110,20 +108,23 @@ class _TransformersRunner(TaskRunner):
 
         if os.path.isdir(dataset):
             for root, _, files in os.walk(dataset):
-                if re.search(r"train", files):
-                    data_file_args["train_file"] = os.path.join(root, files)
-                elif re.search(r"val", files):
-                    data_file_args["validation_file"] = os.path.join(root, files)
-                elif re.search(r"test", files):
-                    data_file_args["test_file"] = os.path.join(root, files)
+                for f in files:
+                    if re.search(r"train", f):
+                        data_file_args["train_file"] = os.path.join(root, f)
+                    elif re.search(r"val", f):
+                        data_file_args["validation_file"] = os.path.join(root, f)
+                    elif re.search(r"test", f):
+                        data_file_args["test_file"] = os.path.join(root, f)
 
                 if (
-                    data_file_args["train_file"]
-                    and data_file_args["validation_file"]
-                    and data_file_args["test_file"]
+                    data_file_args.get("train_file", None)
+                    and data_file_args.get("validation_file", None)
+                    and data_file_args.get("test_file", None)
                 ):
-                    dataset = None
                     break
+
+        if data_file_args:
+            dataset = None
 
         return dataset, data_file_args
 


### PR DESCRIPTION
Ticket: https://app.asana.com/0/1204322589046915/1204958994867569/f

### Summary

Currently, our transformer workflows expect public datasets for the `data` arg when running sparsify auto and all other data files should be passed in to kwargs. This PR checks if the `data` arg passed in is a directory and if it is, populates the kwargs for the user and sets the original `data` arg to None. 

Made a couple of assumptions:
-  The train, test and val data files in the `data` arg directory should have the subtrings `train`, `test` and `val` in the filenames
-  Only one train, test and val file is present with the appropriate substring in the name. If multiple are present, it will only use one.
- You will either provide a data directory or a publicly available dataset that we then download within sparseml

No assumptions are made about the level the files are in the directory/directory structure by using `os.walk`

### Sample `data` directory structure 

```
- data_for_training/
     - some_train_file.json
     - some_validation_file.json
     - test_dir/
           - some_test_file.json
```
or

```
- data_for_training/
     - some_train_file.json
     - some_validation_file.json
     - some_test_file.json
```




