### PR TITLE
Turn QAT folding on by default

### DIFF
--- a/src/sparsify/auto/tasks/image_classification/args.py
+++ b/src/sparsify/auto/tasks/image_classification/args.py
@@ -158,3 +158,10 @@ class ImageClassificationExportArgs(_ImageClassificationBaseArgs):
     num_classes: Optional[int] = Field(
         default=None, description="number of classes for model load/export"
     )
+    convert_qat: bool = Field(
+        default=True,
+        description=(
+            "if True, exports of torch QAT graphs will be converted to a fully  "
+            "quantized representation. Default is True"
+        ),
+    )

--- a/src/sparsify/auto/tasks/transformers/args.py
+++ b/src/sparsify/auto/tasks/transformers/args.py
@@ -697,7 +697,7 @@ class TransformersExportArgs(BaseArgs):
         description="Sequence length to use. Default is 384. Can be overwritten later",
     )
     no_convert_qat: bool = Field(
-        default=True,
+        default=False,
         description=(
             "Set flag to not perform QAT to fully quantized conversion after export"
         ),


### PR DESCRIPTION
This PR turns on QAT folding on by default, so that `sprasify.training_aware` and `sparsify.sparse_transfer` always return fully quantized graphs.

Note that YOLOv5 always does QAT folding by default.

**Test Plan**
Tested with integration tests yet to land - https://github.com/neuralmagic/sparsify/pull/217