### PR TITLE
[transformers] unwrap GLUE dataset alias for classification sparse transfer+training aware

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ _deps = [
     "setuptools>=56.0.0",
     "optuna>=3.0.2",
     "onnxruntime-gpu",
-    "protobuf<=3.20.1,>=3.12.2",
 ]
 _nm_deps = [
     f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_nm_deps}",

--- a/src/sparsify/auto/tasks/transformers/runner.py
+++ b/src/sparsify/auto/tasks/transformers/runner.py
@@ -67,15 +67,28 @@ class _TransformersRunner(TaskRunner):
         :param config: training config to generate run for
         :return: tuple of training and export arguments
         """
+
+        kwargs = config.kwargs
+        if config.task == TASK_REGISTRY.get("text_classification") and (
+            config.dataset in _GLUE_TASK_NAMES
+        ):
+            # text classification GLUE datasets need special treatment
+            # since the proper dataset names are set as "task" with
+            # the top level dataset as "glue"
+            dataset_name = "glue"
+            kwargs["task_name"] = config.dataset
+        else:
+            dataset_name = config.dataset
+
         train_args = cls.train_args_class(
             model_name_or_path=config.base_model,
             recipe=config.recipe,
             recipe_args=config.recipe_args,
-            dataset_name=config.dataset,
+            dataset_name=dataset_name,
             distill_teacher=config.distill_teacher
             if not config.distill_teacher == "off"
             else "disable",
-            **config.kwargs,
+            **kwargs,
         )
 
         export_args = TransformersExportArgs(
@@ -248,6 +261,23 @@ _TASK_TO_EXPORT_TASK = {
     "question_answering": "qa",
     "text_classification": "glue",
     "token_classification": "ner",
+}
+
+
+# https://huggingface.co/datasets/glue
+_GLUE_TASK_NAMES = {
+    "ax",
+    "cola",
+    "mnli",
+    "mnli_matched",
+    "mnli_mismatched",
+    "mrpc",
+    "qnli",
+    "qqp",
+    "rte",
+    "sst2",
+    "stsb",
+    "wnli",
 }
 
 

--- a/src/sparsify/auto/tasks/transformers/runner.py
+++ b/src/sparsify/auto/tasks/transformers/runner.py
@@ -68,18 +68,18 @@ class _TransformersRunner(TaskRunner):
         a tuple of run args in the order (train_args, export_arts)
         :param config: training config to generate run for
         :return: tuple of training and export arguments
-        """  
+        """
         dataset_name, data_file_args = cls.parse_data_args(config.dataset)
         config.kwargs.update(data_file_args)
-  
+
         if config.task == TASK_REGISTRY.get("text_classification") and (
-            dataset in _GLUE_TASK_NAMES
+            dataset_name in _GLUE_TASK_NAMES
         ):
             # text classification GLUE datasets need special treatment
             # since the proper dataset names are set as "task" with
             # the top level dataset as "glue"
+            config.kwargs["task_name"] = dataset_name
             dataset_name = "glue"
-            config.kwargs["task_name"] = config.dataset
 
         train_args = cls.train_args_class(
             model_name_or_path=config.base_model,


### PR DESCRIPTION
glue datasets in HF such as sst2 and qqp are actually stored under the glue dataset name with their task names as the desired dataset name. this PR adds a connivence in the auto pathways to nest any recognized glue datasets under the glue namespace

**testing:**
reproduced and fixed error for minimal reproducible command:
```
sparsify.run sparse-transfer --use-case text-classification --data qqp
```