### PR TITLE
[one shot] allow custom use cases with warning

### DIFF
--- a/src/sparsify/cli/run.py
+++ b/src/sparsify/cli/run.py
@@ -34,7 +34,7 @@ def main():
 
 
 @main.command()
-@opts.add_info_opts
+@opts.add_info_opts(require_known_use_case=False)
 @opts.add_model_opts(require_model=True)
 @opts.add_data_opts
 @opts.add_deploy_opts
@@ -66,7 +66,7 @@ def one_shot(**kwargs):
 
 
 @main.command()
-@opts.add_info_opts
+@opts.add_info_opts(require_known_use_case=True)
 @opts.add_model_opts(require_model=False)
 @opts.add_data_opts
 @opts.add_deploy_opts
@@ -85,7 +85,7 @@ def sparse_transfer(**kwargs):
 
 
 @main.command()
-@opts.add_info_opts
+@opts.add_info_opts(require_known_use_case=True)
 @opts.add_model_opts(require_model=True)
 @opts.add_data_opts
 @opts.add_deploy_opts


### PR DESCRIPTION
no reason to not allow custom use cases for one shot, for now, leaves warning that some features may be missing

**testing**
minimal reproducible example now passing:
```
sparsify.run one-shot --use-case some-custom-usecase --model mobilenet.onnx --data imagenet-val-sample-tiny/ --optim-level 0
```