### PR TITLE
Fix Sparsifyml not installed prompt

### DIFF
--- a/src/sparsify/check_environment/ort_health.py
+++ b/src/sparsify/check_environment/ort_health.py
@@ -25,8 +25,9 @@ import onnxruntime as ort
 from deepsparse.utils import generate_random_inputs, get_input_names
 from sparsify.login import import_sparsifyml_authenticated
 
+
 import_sparsifyml_authenticated()
-from sparsifyml.one_shot.utils import run_onnx_model # noqa: E402
+from sparsifyml.one_shot.utils import run_onnx_model  # noqa: E402
 
 
 __all__ = ["check_ort_health"]

--- a/src/sparsify/check_environment/ort_health.py
+++ b/src/sparsify/check_environment/ort_health.py
@@ -23,7 +23,10 @@ from onnx import TensorProto, helper
 
 import onnxruntime as ort
 from deepsparse.utils import generate_random_inputs, get_input_names
-from sparsifyml.one_shot.utils import run_onnx_model
+from sparsify.login import import_sparsifyml_authenticated
+
+import_sparsifyml_authenticated()
+from sparsifyml.one_shot.utils import run_onnx_model # noqa: E402
 
 
 __all__ = ["check_ort_health"]


### PR DESCRIPTION
The recently added environment check cli was missing authenticated import of sparsifyml, 
This led to a `ModuleNotFoundError` instead of a `SparsifyLoginRequired`

Current PR fixes that.

Test Command:
```bash
sparsify.run sparse-transfer --use-case image-classification --data /network/datasets/imagenette-160 --optim-level 25
```

Command Output:

Before this PR: (Reported by @dsikka)
```bash
Traceback (most recent call last):
  File "/home/dsikka/venvs/sparsify_main/bin/sparsify.run", line 5, in <module>
    from sparsify.cli.run import main
  File "/home/dsikka/sparsify/src/sparsify/cli/run.py", line 21, in <module>
    from sparsify.check_environment import auto_checks, one_shot_checks
  File "/home/dsikka/sparsify/src/sparsify/check_environment/__init__.py", line 19, in <module>
    from .ort_health import *
  File "/home/dsikka/sparsify/src/sparsify/check_environment/ort_health.py", line 26, in <module>
    from sparsifyml.one_shot.utils import run_onnx_model
ModuleNotFoundError: No module named 'sparsifyml'
```

After this PR:

```bash
$ sparsify.run sparse-transfer --use-case image-classification --data /network/datasets/imagenette-160 --optim-level 25
Traceback (most recent call last):
  File "/home/rahul/venvs/sparsify/bin/sparsify.run", line 5, in <module>
    from sparsify.cli.run import main
  File "/home/rahul/projects/sparsify/src/sparsify/cli/run.py", line 21, in <module>
    from sparsify.check_environment import auto_checks, one_shot_checks
  File "/home/rahul/projects/sparsify/src/sparsify/check_environment/__init__.py", line 19, in <module>
    from .ort_health import *
  File "/home/rahul/projects/sparsify/src/sparsify/check_environment/ort_health.py", line 29, in <module>
    import_sparsifyml_authenticated()
  File "/home/rahul/projects/sparsify/src/sparsify/login.py", line 137, in import_sparsifyml_authenticated
    authenticate()
  File "/home/rahul/projects/sparsify/src/sparsify/login.py", line 150, in authenticate
    raise SparsifyLoginRequired(
sparsify.utils.exceptions.SparsifyLoginRequired: No valid sparsify credentials found. Please run `sparsify.login`

```
