### PR TITLE
Add functionality to build yolov5 yaml

### DIFF
--- a/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
+++ b/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
@@ -121,15 +121,31 @@ class Yolov5Runner(TaskRunner):
             dynamic=True,
         )
 
-        return train_args, export_args
+        #return train_args, export_args
 
     @classmethod
     def parse_data_args(cls, dataset: str) -> str:
         """
-        Check if the dataset provided is a data directory.
+        Check if the dataset provided is a data directory. If it is, buid a yolov5 yaml
+        file based on the provided data directory path. An example of the directory
+        structure for the provided directory path is shown below. There must
+        subdirectories in the provided directory named `images`, `labels` and a text
+        file called `classes.txt` which includes the list of the classes for the
+        particular dataset, ordered by class id. For details on what images and labels
+        should look like, please see the yolov5 repository:
+        https://github.com/ultralytics/yolov5/tree/master.
 
         Example directory structure:
         - data_for_training/
+            - labels/
+                - train/
+                - val/
+                - test/
+            - images/
+                - train/
+                - validation/
+                - test/
+            - classes.txt
 
         :params dataset: inputted data string arg. Assumed to either be a dataset which
         can be downloaded publicly or a locally available directory containing
@@ -137,50 +153,73 @@ class Yolov5Runner(TaskRunner):
 
         :returns: path to yaml to download or the newly built yaml. If the data string
         arg is a yaml for a publicly available dataset, this function will return the
-        same string.
+        same string. Otherwise, the path to the newly generated yaml will be returned.
         """
         data_file_args = {}
+        IMAGE_DIR = "images"
+        CLASS_LIST_PATH = "classes.txt"
+        YAML_PATH = "data_local.yaml"
 
         def _check_and_update_file(file_type: str, path: str):
             if data_file_args.get(file_type, None):
                 data_file_args[file_type].append(path)
             else:
                 data_file_args[file_type] = [path]
-                        
-        # TODO: do we expect train/test/val with images and labels in each?
-        # or the other way around
+
         if os.path.isdir(dataset):
-            for root, dirs, _ in os.walk(dataset):
-                for d in dirs:
-                    # May have to do further processing on the root string as
-                    # yolov5 expects relative paths
-                    current_path = os.path.append(root, d)
-                    if re.search(r"train", f):
-                        _check_and_update_file("train", current_path)
-                    elif re.search(r"val", f):
-                        _check_and_update_file("val", current_path)
-                    elif re.search(r"test", f):
-                        _check_and_update_file("test", current_path)
+            image_path = os.path.join(dataset, IMAGE_DIR)
+            class_list_path = os.path.join(dataset, CLASS_LIST_PATH)
+
+            if not os.path.exists(image_path):
+                raise ValueError(
+                    f"The the provided directory path {dataset} "
+                    "does not contain a folder called `images`. A subdirectory must "
+                    "exist which contains the data folders."
+                )
+
+            if not os.path.exists(class_list_path):
+                raise ValueError(
+                    f"The the provided directory path {dataset} "
+                    "does not contain a classes.txt file. A file must be "
+                    "present which includes a list of the classes for the dataset."
+                )
+
+            data_file_args["path"] = dataset
+
+            for d in os.listdir(image_path):
+                current_path = os.path.join(IMAGE_DIR, d)
+                if re.search(r"train", d):
+                    _check_and_update_file("train", current_path)
+                elif re.search(r"val", d):
+                    _check_and_update_file("val", current_path)
+                elif re.search(r"test", d):
+                    _check_and_update_file("test", current_path)
 
             if not (
-                data_file_args.get("train", None)
-                and data_file_args.get("val", None)
+                data_file_args.get("train", None) and data_file_args.get("val", None)
             ):
                 raise Exception(
-                    "No training or validation files found. Be sure the "
-                    "directory provided to the data arg contains json or csv "
-                    "files with the train and val substrings in the filenames."
+                    "No training or validation folders found. Be sure the "
+                    "directory provided to the data arg contains folders "
+                    "with the train and val substrings in the filenames."
                 )
 
         if data_file_args:
             # Store the newly generated yaml in the same directory as the data
-            data_file_args["path"] = dataset
-            classes = {} # TODO: how do we expect to process the labels?
-            dataset = os.path.join(dataset, "data_local.yaml")
-            with open(dataset, "w") as file:
+            dataset = os.path.join(dataset, YAML_PATH)
+
+            with open(class_list_path, "r") as f:
+                class_list = f.readlines()
+
+            classes = {}
+            for class_id in range(len(class_list)):
+                classes[class_id] = class_list[class_id].strip()
+
+            with open(dataset, "w") as f:
                 yaml.safe_dump(
-                    {**{"names": classes}, **data_file_args},
-                    file,
+                    {**data_file_args, **{"names": classes}},
+                    f,
+                    sort_keys=False
                 )
 
         return dataset

--- a/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
+++ b/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
@@ -217,9 +217,7 @@ class Yolov5Runner(TaskRunner):
 
             with open(dataset, "w") as f:
                 yaml.safe_dump(
-                    {**data_file_args, **{"names": classes}},
-                    f,
-                    sort_keys=False
+                    {**data_file_args, **{"names": classes}}, f, sort_keys=False
                 )
 
         return dataset

--- a/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
+++ b/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
@@ -121,7 +121,7 @@ class Yolov5Runner(TaskRunner):
             dynamic=True,
         )
 
-        #return train_args, export_args
+        return train_args, export_args
 
     @classmethod
     def parse_data_args(cls, dataset: str) -> str:


### PR DESCRIPTION
### Summary:
- Provide the functionality to build a yolov5 yaml file, given the user provides an input directory to the `data` arg.  
- The following assumptions were made about the directory structure and a sample directory structure is shown below

#### Assumptions:
- The directory passed in contains an `images` subdirectory, a `labels` subdirectory, and a file called `classes.txt` which contains the classes, ordered by class id
- Each of the `images` and `labels` subdirectories contains training, testing and validation folders
- The labels should already be in the format expected by yolov5
- yolov5 assumes the train, test and validation directories have identical names in both the `images` and `labels` folders

Sample Directory Structure:

```
- data_for_training/
    - labels/
        - train/
        - val/
        - test/
    - images/
        - train/
        - val/
        - test/
    - classes.txt
```


### Example Inputs/Outputs:

Input directory structure:

```
dsikka@quad-mle-2:~/some_dir/some_dataset$ ls
classes.txt  images
```
`classes.txt`:
```
dog
cat 
house 
park

```
`images` dir:
```
dsikka@quad-mle-2:~/some_dir/some_dataset/images$ ls
test  train  val
```

yaml file produced:

```
path: some_dataset/
train:
- images/train
test:
- images/test
val:
- images/val
names:
  0: dog
  1: cat
  2: house
  3: park
```

### Testing:
- Locally tested `training_aware` runs by passing in a local directory to the `data` arg.  yaml file produced is correct and training runs to completion