### PR TITLE
[ImageClassification] Check if the folder exists for custom datasets

### DIFF
--- a/src/sparsify/auto/tasks/image_classification/runner.py
+++ b/src/sparsify/auto/tasks/image_classification/runner.py
@@ -77,6 +77,12 @@ class ImageClassificationRunner(TaskRunner):
         if "dataset" not in config.kwargs:
             # custom datasets are set to imagefolder
             config.kwargs["dataset"] = "imagefolder"
+            if not os.path.exists(config.dataset):
+                raise FileNotFoundError(
+                    f"The custom dataset {config.dataset} "
+                    "does not exist. Please ensure that the path provided is correct."
+                )
+
         if "model_tag" not in config.kwargs:
             config.kwargs["model_tag"] = "sparsify_auto_image_classification"
         train_args = ImageClassificationTrainArgs(


### PR DESCRIPTION
For this bug: https://app.asana.com/0/1204777926187571/1205045628929357/f

In the case where the user is providing a custom dataset, we want to check if the dataset directory exists. 