### PR TITLE
Add deployment instructions to `README.md`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include src/sparsify/ui/ *
 include LICENSE
+include src/sparsify/auto/tasks/deployment_instructions.md

--- a/src/sparsify/auto/tasks/deployment_instructions.md
+++ b/src/sparsify/auto/tasks/deployment_instructions.md
@@ -1,0 +1,82 @@
+# Deployment Guide
+​
+We recommend deploying with the [DeepSparse](https://github.com/neuralmagic/deepsparse) Engine for the best performance with sparsified models on CPUs.
+The deployment folder contains everything necessary to benchmark and deploy a sparsified model with the DeepSparse Engine.
+​
+## Requirements
+​
+A Linux-based CPU system with Python versions 3.8-3.10 installed and AVX2 or greater instruction sets is required to run the DeepSparse Engine.
+The DeepSparse Engine is not currently supported on Windows or MacOS.
+To install DeepSparse, its dependencies, and check your system, run the following commands:
+​
+```bash
+pip install deepsparse
+deepsparse.check_hardware
+```
+​
+Other installation options may be needed, depending on your use case.
+For more details and other installation options, see the [Installation Guide](https://github.com/neuralmagic/deepsparse).
+​
+For more information on hardware support and system requirements, see the [Support and Requirements Guide](https://github.com/neuralmagic/deepsparse).
+​
+## Benchmarking
+​
+The `deepsparse.benchmark` command enables benchmarking of an ONNX model on your system.
+The command takes a model path as a minimum argument and will run the model through a series of inference runs using random data.
+For example:
+​
+```bash
+deepsparse.benchmark model.onnx
+```
+​
+For more information on the `deepsparse.benchmark` command, see the [Benchmarking Guide](https://github.com/neuralmagic/deepsparse/blob/main/docs/user-guide/deepsparse-benchmarking.md).
+​
+## Pipeline Deployments
+​
+DeepSparse contains many pipeline deployments for different use cases.
+These pipelines package up the model inference and any pre- and post-processing steps into a single, optimized callable for deployment.
+Additionally, custom pipelines are supported.
+For example, a sample custom pipeline for ImageNet is provided below:
+​
+```python
+from deepsparse.pipelines.custom_pipeline import CustomTaskPipeline
+from torchvision import transforms
+from PIL import Image
+import torch
+​
+preprocess_transforms = transforms.Compose([
+    transforms.Resize(256),
+    transforms.CenterCrop(224),
+    transforms.ToTensor(),
+    transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+])
+​
+def preprocess(img_file):
+    with open(img_file, "rb") as img_file:
+        img = Image.open(img_file)
+        img = img.convert("RGB")
+    img = preprocess_transforms(img)
+    batch = torch.stack([img])
+    return [batch.numpy()] 
+​
+custom_pipeline = CustomTaskPipeline(
+    model_path="zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned90_quant-none",
+    process_inputs_fn=preprocess,
+)
+​
+scores, probs = custom_pipeline("goldfish.jpg")
+```
+​
+For more information on the available pipelines and how to create custom pipelines, see the [Pipeline Deployment Guide](https://github.com/neuralmagic/deepsparse/blob/main/docs/user-guide/deepsparse-benchmarking.md).
+​
+## Server Deployments
+​
+DeepSparse additionally contains a performant server deployment for different use cases.
+The server deployment packages up the model inference and any pre- and post-processing steps into a single, optimized HTTP request for deployment.
+To start the server, run the following command with the appropriate arguments:
+​
+```bash
+deepsparse.server --task TASK --model_path ./deployment
+```
+​
+For more information on the `deepsparse.server` command, see the [Server Deployment Guide](zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned90_quant-none).

--- a/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
+++ b/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
@@ -187,8 +187,12 @@ class Yolov5Runner(TaskRunner):
         if not os.path.isfile(onnx_file):
             return False
 
+        # Rename the exported model. yolo5 gives the same name during export
+        new_onnx_name = onnx_file.replace("last", "model")
+        os.rename(onnx_file, new_onnx_name)
+
         # Check onnx graph
-        model = onnx.load(onnx_file)
+        model = onnx.load(new_onnx_name)
         try:
             onnx.checker.check_model(model)
         except Exception:

--- a/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
+++ b/src/sparsify/auto/tasks/object_detection/yolov5/runner.py
@@ -187,12 +187,8 @@ class Yolov5Runner(TaskRunner):
         if not os.path.isfile(onnx_file):
             return False
 
-        # Rename the exported model. yolo5 gives the same name during export
-        new_onnx_name = onnx_file.replace("last", "model")
-        os.rename(onnx_file, new_onnx_name)
-
         # Check onnx graph
-        model = onnx.load(new_onnx_name)
+        model = onnx.load(onnx_file)
         try:
             onnx.checker.check_model(model)
         except Exception:

--- a/src/sparsify/auto/tasks/runner.py
+++ b/src/sparsify/auto/tasks/runner.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import gc
 import json
 import logging
 import os
+import pkgutil
 import shutil
 import socket
 import warnings
@@ -153,7 +153,6 @@ class TaskRunner:
         self.dashed_cli_kwargs = False  # True if CLI args require "-" as word separator
 
         self.train_args, self.export_args = self.config_to_args(self.config)
-
         self.hardware_specs = analyze_hardware()
         self.tune_args_for_hardware(self.hardware_specs)
 
@@ -412,8 +411,10 @@ class TaskRunner:
         _LOGGER.info("Deleting %s" % origin_directory)
         shutil.rmtree(origin_directory)
 
-        with open(os.path.join(deploy_directory, "README.md"), "x") as f:
-            f.write("deployment instructions will go here")
+        readme_path = os.path.join(deploy_directory, "README.md")
+        instruc = pkgutil.get_data("sparsify.auto", "tasks/deployment_instructions.md")
+        with open(readme_path, "wb") as f:
+            f.write(instruc)
         _LOGGER.info("Deployment directory moved to %s" % deploy_directory)
 
     @abstractmethod


### PR DESCRIPTION
- Add deployment instructions to the source code
- Add step to write the instructions to the `deployments` directory produced for the workflow and save the  file as `README.md`

Tested locally