### PR TITLE
Update deployment instructions to install deepsparse[server]

### DIFF
--- a/src/sparsify/auto/tasks/deployment_instructions.md
+++ b/src/sparsify/auto/tasks/deployment_instructions.md
@@ -10,7 +10,7 @@ The DeepSparse Engine is not currently supported on Windows or MacOS.
 To install DeepSparse, its dependencies, and check your system, run the following commands:
 ​
 ```bash
-pip install deepsparse
+pip install deepsparse[server]
 deepsparse.check_hardware
 ```
 ​

--- a/src/sparsify/auto/tasks/deployment_instructions.md
+++ b/src/sparsify/auto/tasks/deployment_instructions.md
@@ -64,8 +64,10 @@ custom_pipeline = CustomTaskPipeline(
     process_inputs_fn=preprocess,
 )
 ​
-scores, probs = custom_pipeline("goldfish.jpg")
+scores, probs = custom_pipeline("buddy.jpeg")
 ```
+(Note: Download [buddy.jpeg](https://github.com/neuralmagic/deepsparse/blob/main/tests/deepsparse/pipelines/sample_images/buddy.jpeg))
+
 ​
 For more information on the available pipelines and how to create custom pipelines, see the [Pipeline Deployment Guide](https://github.com/neuralmagic/deepsparse/blob/main/docs/user-guide/deepsparse-benchmarking.md).
 ​


### PR DESCRIPTION
Update deployment instructions to install `deepsparse[server]`
Also added a link to download sample image

Note: this wasn't updated to deepsparse-nightly; as once 1.6 is recut deepsparse[server] would be enough 