### PR TITLE
Move empty directory removal to sparseml instead of sparsify

### DIFF
--- a/src/sparsify/auto/tasks/image_classification/runner.py
+++ b/src/sparsify/auto/tasks/image_classification/runner.py
@@ -77,11 +77,6 @@ class ImageClassificationRunner(TaskRunner):
         if "dataset" not in config.kwargs:
             # custom datasets are set to imagefolder
             config.kwargs["dataset"] = "imagefolder"
-            if not os.path.exists(config.dataset):
-                raise FileNotFoundError(
-                    f"The custom dataset {config.dataset} "
-                    "does not exist. Please ensure that the path provided is correct."
-                )
 
         if "model_tag" not in config.kwargs:
             config.kwargs["model_tag"] = "sparsify_auto_image_classification"


### PR DESCRIPTION
- Default behaviour involves the user passing in just the `data` arg and this always results in `imagefolder` being populated in for the `dataset` arg, for both custom datasets and datasets where we download public data (this shouldn't be happening/should be separated further in a follow-up PR)
- However, we only want to check the existence of folders for custom datasets, not public datasets we haven't pulled down.
- Therefore, remove the check and error  
- This should also just be done in sparseml, since click.Path() is where the folder is created.


Tested locally using the following command:
`sparsify.run sparse-transfer --use-case image-classification --data imagenette --optim-level 0.5`