### PR TITLE
LLM Finetune Functionality

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include src/sparsify/ui/ *
 include LICENSE
 include src/sparsify/auto/tasks/deployment_instructions.md
+include src/sparsify/auto/samples/finetune_llmfoundry_sample.yaml

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ def _setup_entry_points() -> Dict:
             "sparsify.run=sparsify.cli.run:main",
             "sparsify.login=sparsify.login:main",
             "sparsify.check_environment=sparsify.check_environment.main:main",
+            "finetune=sparsify.auto.tasks.finetune.finetune:main",
         ]
     }
 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,8 @@ _dev_deps = [
     "fastai>=2.7.7",
 ]
 
+_llm_deps = ["llm-foundry==0.2.0"]
+
 
 def _setup_packages() -> List:
     return find_packages(
@@ -72,7 +74,7 @@ def _setup_install_requires() -> List:
 
 
 def _setup_extras() -> Dict:
-    return {"dev": _dev_deps}
+    return {"dev": _dev_deps, "llm": _llm_deps}
 
 
 def _setup_entry_points() -> Dict:

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ def _setup_entry_points() -> Dict:
             "sparsify.run=sparsify.cli.run:main",
             "sparsify.login=sparsify.login:main",
             "sparsify.check_environment=sparsify.check_environment.main:main",
-            "finetune=sparsify.auto.tasks.finetune.finetune:main",
+            "finetune=sparsify.auto.tasks.finetune.finetune:parse_args_and_run",
         ]
     }
 

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,9 @@ version_major_minor = version
 # load and overwrite version and release info from sparseml package
 exec(open(os.path.join("src", "sparsify", "version.py")).read())
 print(f"loaded version {version} from src/sparsify/version.py")
-version_nm_deps = f"{version_major_minor}.0"
+version_nm_deps = f"{version_major_minor}.0.202308"
 
 _PACKAGE_NAME = "sparsify" if is_release else "sparsify-nightly"
-
 
 _deps = [
     "pydantic>=1.8.2,<2.0.0",
@@ -39,13 +38,14 @@ _deps = [
     "setuptools>=56.0.0",
     "optuna>=3.0.2",
     "onnxruntime-gpu",
-]
-_nm_deps = [
     f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_nm_deps}",
-    f"{'sparseml' if is_release else 'sparseml-nightly'}[torchvision,transformers,yolov5]~={version_nm_deps}",  # noqa E501
     f"{'deepsparse' if is_release else 'deepsparse-nightly'}~={version_nm_deps}",
+    f"{'sparseml' if is_release else 'sparseml-nightly'}[torchvision,yolov5]~={version_nm_deps}",  # noqa E501
 ]
 
+_nm_deps = [
+    f"{'sparseml' if is_release else 'sparseml-nightly'}[transformers]~={version_nm_deps}",  # noqa E501
+]
 
 _dev_deps = [
     "black>=20.8b1",
@@ -56,7 +56,10 @@ _dev_deps = [
     "fastai>=2.7.7",
 ]
 
-_llm_deps = ["llm-foundry==0.2.0"]
+_llm_deps = [
+    "llm-foundry==0.2.0",
+    f"{'nm-transformers' if is_release else 'nm-transformers-nightly'}",
+]
 
 
 def _setup_packages() -> List:
@@ -70,11 +73,11 @@ def _setup_package_dir() -> Dict:
 
 
 def _setup_install_requires() -> List:
-    return _nm_deps + _deps
+    return _deps
 
 
 def _setup_extras() -> Dict:
-    return {"dev": _dev_deps, "llm": _llm_deps}
+    return {"dev": _dev_deps, "_nm_deps": _nm_deps, "llm": _llm_deps}
 
 
 def _setup_entry_points() -> Dict:

--- a/src/sparsify/auto/finetune.py
+++ b/src/sparsify/auto/finetune.py
@@ -46,8 +46,8 @@ class LLMFinetuner:
     LLMFinetuner which allows finetuning of LLM Models using llmfoundry. Finetuning is
     heavily dependent on providing a llmfoundary-compliant yaml file which sets up
     the training, including which pretrained model to pull as well as the data that is
-    to be used for finetuning. Please see the example yaml provided or the llmfoundry
-    repo for additional examples:
+    to be used for finetuning. Please see the example yaml under samples or the
+    llmfoundry repo for additional examples:
     https://github.com/mosaicml/llm-foundry/blob/main/scripts/train/finetune_example/
     """
 

--- a/src/sparsify/auto/finetune.py
+++ b/src/sparsify/auto/finetune.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+from typing import Dict, Union
+
+from torch.utils.data import DataLoader
+
+from composer import Trainer
+from composer.core import Evaluator
+from composer.models import HuggingFaceModel
+from composer.utils import dist, reproducibility
+from llmfoundry import (
+    COMPOSER_MODEL_REGISTRY,
+    build_finetuning_dataloader,
+    build_text_denoising_dataloader,
+)
+from llmfoundry.data.text_data import build_text_dataloader
+from llmfoundry.utils.builders import build_optimizer, build_scheduler, build_tokenizer
+from omegaconf import DictConfig
+from omegaconf import OmegaConf as om
+from sparsify.schemas import APIArgs
+from transformers import PreTrainedTokenizerBase
+
+
+__all__ = ["LLMFinetuner"]
+
+TEXT_DENOISING_MODELS = ["hf_prefix_lm", "hf_t5"]
+TEXT_MODELS = ["hf_causal_lm"]
+
+
+class LLMFinetuner:
+    """
+    LLMFinetuner which allows finetuning of LLM Models using llmfoundry. Finetuning is
+    heavily dependent on providing a llmfoundary-compliant yaml file which sets up
+    the training, including which pretrained model to pull as well as the data that is
+    to be used for finetuning. Please see the example yaml provided or the llmfoundry
+    repo for additional examples:
+    https://github.com/mosaicml/llm-foundry/blob/main/scripts/train/finetune_example/
+    """
+
+    def __init__(self, api_args: APIArgs) -> None:
+        if os.path.exists(api_args.dataset):
+            if Path(api_args.dataset).suffix not in [".yaml", ".yml"]:
+                raise RuntimeError(
+                    "LLMFinetuner expects a yaml file compliant with llmfoundry."
+                )
+            with open(api_args.dataset) as yaml_file:
+                self._config = om.load(yaml_file)
+        else:
+            raise FileNotFoundError(
+                f"{api_args.dataset} does not exist. Plase ensure "
+                " the yaml file exists and the path provided is correct."
+            )
+
+        self._model_name = self._config["model"]["name"]
+        self._valdiate_yaml()
+
+    @property
+    def model_name(self) -> str:
+        """
+        :return: model name for the LLM
+        """
+        return self._model_name
+
+    def _valdiate_yaml(self):
+        """
+        Validate that the provided yaml is compatible with llmfoundry.
+        """
+        if not self._config.get("train_loader"):
+            raise ValueError(
+                "the provided config file is missing details on the train_loader"
+            )
+
+        data_loaders = [self._config.get("train_loader")]
+        if self._config.get("eval_loader"):
+            data_loaders.append(self._config.get("eval_loader"))
+
+        for loader in data_loaders:
+            if loader["name"] == "text":
+                if self.model_name in TEXT_DENOISING_MODELS:
+                    raise ValueError(
+                        f"Model type {self.model_name} is not supported "
+                        " for text dataloaders. Please use the "
+                        " text_denoising dataloader."
+                    )
+            elif loader["name"] == "text_denoising":
+                if self.model_name in TEXT_MODELS:
+                    raise ValueError(
+                        f"Model type {self.model_name} is not supported "
+                        " for text_denoising dataloaders. Please use the "
+                        " text dataloader."
+                    )
+
+    def _build_model(self, tokenizer: PreTrainedTokenizerBase) -> HuggingFaceModel:
+        """
+        Based on the model name, pull and return the pretrained hugging face model.
+
+        :param tokenizer: transformers tokenizer
+        :return: HuggingFaceModel from the mosaicml composer library
+        """
+        if not COMPOSER_MODEL_REGISTRY.get(self.model_name):
+            raise ValueError(
+                "Please ensure the model name provided is one of "
+                f" {list(COMPOSER_MODEL_REGISTRY.keys())}"
+            )
+        return COMPOSER_MODEL_REGISTRY[self.model_name](self._config.model, tokenizer)
+
+    def _build_dataloaders(
+        self,
+        dataloader_config: DictConfig,
+        tokenizer: PreTrainedTokenizerBase,
+        device_batch_size: int,
+    ) -> DataLoader:
+        """
+        Build a torch dataloader given a DictConfig containing details about the
+        dataloader, the tokenizer that is to be applied to the data, and the batch size
+        for the dataloader.
+
+        :param dataloader_config DictConfig from the omegaconf library, containing
+        details on the dataloader
+        :param tokenizer: transformers tokenizer
+        :param device_batch_size: batch size for the dataloader
+        :return: a torch DataLoader
+        """
+        if dataloader_config.name == "text":
+            return build_text_dataloader(
+                dataloader_config,
+                tokenizer,
+                device_batch_size,
+            )
+        elif dataloader_config.name == "text_denoising":
+            return build_text_denoising_dataloader(
+                dataloader_config,
+                tokenizer,
+                device_batch_size,
+            )
+        elif dataloader_config.name == "finetuning":
+            return build_finetuning_dataloader(
+                dataloader_config,
+                tokenizer,
+                device_batch_size,
+            )
+
+    def _get_fsdp_config(self) -> Union[Dict, None]:
+        """
+        Fetch the fsdp configuration. If <= one gpu devices are available, fsdp is
+        turned off.
+
+        :return: fsdp dictionary if number of cuda devices available is > one, else None
+        """
+        fsdp_config = self._config.get("fsdp_config", None)
+        fsdp_config = (
+            om.to_container(fsdp_config, resolve=True) if fsdp_config else None
+        )
+
+        if dist.get_world_size() <= 1:
+            fsdp_config = None
+
+        return fsdp_config
+
+    def _build_trainer(self) -> Trainer:
+        """
+        Build the trainer object. This involves loading the pretrained model, fetching
+        the tokenizer, and setting up the dataloaders, optimizer, and scheduler.
+
+        :return: mosaicml composer Trainer object
+        """
+        reproducibility.seed_all(self._config.seed)
+
+        tokenizer = build_tokenizer(self._config.tokenizer)
+        model = self._build_model(tokenizer)
+        optimizer = build_optimizer(self._config.optimizer, model)
+        scheduler = build_scheduler(self._config.scheduler)
+
+        train_loader = self._build_dataloaders(
+            self._config.train_loader,
+            tokenizer,
+            self._config.device_train_batch_size,
+        )
+        eval_loader = Evaluator(
+            label="eval",
+            dataloader=self._build_dataloaders(
+                self._config.eval_loader, tokenizer, self._config.device_eval_batch_size
+            ),
+            metric_names=list(model.train_metrics.keys()),
+        )
+
+        trainer = Trainer(
+            run_name=self._config.run_name,
+            model=model,
+            train_dataloader=train_loader,
+            eval_dataloader=[eval_loader],
+            optimizers=optimizer,
+            schedulers=scheduler,
+            max_duration=self._config.max_duration,
+            eval_interval=self._config.eval_interval,
+            precision=self._config.precision,
+            fsdp_config=self._get_fsdp_config(),
+            eval_subset_num_batches=self._config.get("eval_subset_num_batches", -1),
+            log_to_console=self._config.get("log_to_console", False),
+            console_log_interval=self._config.get("console_log_interval", "1ba"),
+            device_train_microbatch_size=self._config.get(
+                "device_train_microbatch_size", "auto"
+            ),
+            save_folder=self._config.get("save_folder", None),
+            save_filename=self._config.get(
+                "save_filename", "ep{epoch}-ba{batch}-rank{rank}.pt"
+            ),
+            save_latest_filename=self._config.get(
+                "save_latest_filename", "latest-rank{rank}.pt"
+            ),
+            save_interval=self._config.get("save_interval", "1000ba"),
+            save_num_checkpoints_to_keep=self._config.get(
+                "save_num_checkpoints_to_keep", 1
+            ),
+            save_overwrite=self._config.get("save_overwrite", False),
+            autoresume=self._config.get("autoresume", False),
+            dist_timeout=self._config.get("dist_timeout", 600.0),
+        )
+        return trainer
+
+    def fine_tune(self):
+        """
+        Run finetuning using the trainer object. Finetuned models will be checkpointed
+        to the coonfigured directory.
+        """
+        trainer = self._build_trainer()
+        trainer.fit()

--- a/src/sparsify/auto/samples/finetune_llmfoundry_sample.yaml
+++ b/src/sparsify/auto/samples/finetune_llmfoundry_sample.yaml
@@ -1,11 +1,11 @@
-max_seq_len: 128
+max_seq_len: 512
 global_seed: 17
-model_name_or_path: gpt2
+model_name_or_path: t5-small
 model_name: ${model_name_or_path}
 load_path:  # set via bash script to be absolute path to your sparse checkpoint
 precision: amp_bf16
 
-max_duration: 2ep # run for 2 epochs
+max_duration: 1ep # run for 2 epochs
 eval_interval: 1ep
 # eval_subset_num_batches: 3  # use this for quick testing
 eval_first: true
@@ -19,9 +19,9 @@ device_eval_batch_size: 4
 run_name: testing_run
 
 model:
-  name: hf_causal_lm
+  name: hf_t5
   pretrained: true
-  pretrained_model_name_or_path: gpt2
+  pretrained_model_name_or_path: t5-small
   max_seq_len: ${max_seq_len}
 
 # Tokenizer
@@ -95,8 +95,11 @@ fsdp_config:
 
 # Logging
 progress_bar: false
-log_to_console: false
+log_to_console: true
 console_log_interval: 1ba
+
+loggers:
+  tensorboard: {"log_dir": "my_logs"}
 
 # Checkpoint to local filesystem or remote object store
 save_interval: 1ep

--- a/src/sparsify/auto/samples/finetune_llmfoundry_sample.yaml
+++ b/src/sparsify/auto/samples/finetune_llmfoundry_sample.yaml
@@ -1,32 +1,43 @@
-max_seq_len: 512
+max_seq_len: 2048
 global_seed: 17
-model_name_or_path: t5-small
-model_name: ${model_name_or_path}
-load_path:  # set via bash script to be absolute path to your sparse checkpoint
+model_name_or_path: mosaicml/mpt-7b-instruct
+load_path:  /storage/dsikka/mpt_7b_instruct_oneshot_sp70.pt
 precision: amp_bf16
 
-max_duration: 1ep # run for 2 epochs
+max_duration: 1ep
 eval_interval: 1ep
 # eval_subset_num_batches: 3  # use this for quick testing
 eval_first: true
 seed: ${global_seed}
 
-device_train_microbatch_size: 1 # set to catch potential OOM cuda errors
-device_train_batch_size: 4
-device_eval_batch_size: 4
+global_train_batch_size: 1
+# for mpt-7b dense:
+# 4 x A100_80GB = "device_train_microbatch_size: 12"
+# 8 x A6000_48GB = "device_train_microbatch_size: 6"
+
+# for mpt-7b sparse (with masks):
+# 8 x A6000_48GB = "device_train_microbatch_size: 4"
+device_train_batch_size: 1
+device_train_microbatch_size: 1
+device_eval_batch_size: 1
 
 # Run Name
-run_name: testing_run
+run_name: test_run
 
 model:
-  name: hf_t5
+  name: hf_causal_lm
   pretrained: true
-  pretrained_model_name_or_path: t5-small
+  pretrained_model_name_or_path: mosaicml/mpt-7b-instruct
   max_seq_len: ${max_seq_len}
+  config_overrides:
+    attn_config:
+      attn_impl: torch
+      # Set this to `true` if using `train_loader.dataset.packing_ratio` below
+      attn_uses_sequence_id: true
 
 # Tokenizer
 tokenizer:
-  name: ${model_name}
+  name: EleutherAI/gpt-neox-20b
   kwargs:
     model_max_length: ${max_seq_len}
 
@@ -83,6 +94,14 @@ optimizer:
   eps: 1.0e-8
   weight_decay: 0.0
 
+# we can't use gradient clipping for sparse training runs because we don't have
+# a way to mask gradients of pruned weights, and thus the global gradient norm
+# will be incorrect
+# algorithms:
+#   gradient_clipping:
+#     clipping_type: norm
+#     clipping_threshold: 1.0
+
 # FSDP
 fsdp_config:
   sharding_strategy: FULL_SHARD
@@ -98,8 +117,15 @@ progress_bar: false
 log_to_console: true
 console_log_interval: 1ba
 
+callbacks:
+  speed_monitor:
+    window_size: 10
+  lr_monitor: {}
+  memory_monitor: {}
+  runtime_estimator: {}
+
 loggers:
-  tensorboard: {"log_dir": "my_logs"}
+  tensorboard: {}
 
 # Checkpoint to local filesystem or remote object store
 save_interval: 1ep

--- a/src/sparsify/auto/samples/finetune_llmfoundry_sample.yaml
+++ b/src/sparsify/auto/samples/finetune_llmfoundry_sample.yaml
@@ -1,0 +1,105 @@
+max_seq_len: 128
+global_seed: 17
+model_name_or_path: gpt2
+model_name: ${model_name_or_path}
+load_path:  # set via bash script to be absolute path to your sparse checkpoint
+precision: amp_bf16
+
+max_duration: 2ep # run for 2 epochs
+eval_interval: 1ep
+# eval_subset_num_batches: 3  # use this for quick testing
+eval_first: true
+seed: ${global_seed}
+
+device_train_microbatch_size: 1 # set to catch potential OOM cuda errors
+device_train_batch_size: 4
+device_eval_batch_size: 4
+
+# Run Name
+run_name: testing_run
+
+model:
+  name: hf_causal_lm
+  pretrained: true
+  pretrained_model_name_or_path: gpt2
+  max_seq_len: ${max_seq_len}
+
+# Tokenizer
+tokenizer:
+  name: ${model_name}
+  kwargs:
+    model_max_length: ${max_seq_len}
+
+# Dataloaders
+train_loader:
+  name: finetuning
+  dataset:
+    hf_name: mosaicml/dolly_hhrlhf
+    split: train
+    max_seq_len: ${max_seq_len}
+    allow_pad_trimming: false
+    decoder_only_format: true
+    # # Use `python llmfoundry/data/packing.py --yaml-path /path/to/this/yaml/ ...`
+    # # to profile this run's optimal packing_ratio as it depends on GPU count,
+    # # batch size, sequence length
+    packing_ratio: 13 # padding=0.36%, waste=0.79%
+    shuffle: true
+  drop_last: false
+  num_workers: 8
+  pin_memory: false
+  prefetch_factor: 2
+  persistent_workers: true
+  timeout: 0
+
+eval_loader:
+  name: finetuning
+  dataset:
+    hf_name: mosaicml/dolly_hhrlhf
+    split: test
+    max_seq_len: ${max_seq_len}
+    allow_pad_trimming: false
+    decoder_only_format: true
+    packing_ratio: 13
+    shuffle: false
+  drop_last: false
+  num_workers: 8
+  pin_memory: false
+  prefetch_factor: 2
+  persistent_workers: true
+  timeout: 0
+
+# Optimization
+scheduler:
+  name: linear_decay_with_warmup
+  t_warmup: 20ba
+  alpha_f: 0
+
+optimizer:
+  name: decoupled_adamw
+  lr: 1e-4
+  betas:
+  - 0.9
+  - 0.999
+  eps: 1.0e-8
+  weight_decay: 0.0
+
+# FSDP
+fsdp_config:
+  sharding_strategy: FULL_SHARD
+  mixed_precision: FULL
+  activation_checkpointing: true
+  activation_checkpointing_reentrant: false
+  activation_cpu_offload: false
+  limit_all_gathers: true
+  verbose: false
+
+# Logging
+progress_bar: false
+log_to_console: false
+console_log_interval: 1ba
+
+# Checkpoint to local filesystem or remote object store
+save_interval: 1ep
+save_num_checkpoints_to_keep: 1  # Important, this cleans up checkpoints saved to DISK
+save_folder: output_dir/{run_name}/checkpoints
+save_overwrite: true

--- a/src/sparsify/auto/scripts/main.py
+++ b/src/sparsify/auto/scripts/main.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import yaml
 
+from sparsify.auto.finetune import LLMFinetuner
 from sparsify.auto.tasks import TaskRunner
 from sparsify.auto.utils import (
     api_request_config,
@@ -35,6 +36,11 @@ _LOGGER = logging.getLogger("auto_banner")
 def main(api_args: APIArgs):
     initialize_banner_logger()
 
+    if api_args.task == "finetune":
+        runner = LLMFinetuner(api_args)
+        runner.fine_tune()
+        return
+
     # Set up directory for saving
     (
         train_directory,
@@ -51,6 +57,7 @@ def main(api_args: APIArgs):
     _LOGGER.info(f"TensorBoard listening on {url}")
 
     # Request config from api and instantiate runner
+
     raw_config = api_request_config(api_args)
     config = SparsificationTrainingConfig(**raw_config)
     runner = TaskRunner.create(config)

--- a/src/sparsify/auto/scripts/main.py
+++ b/src/sparsify/auto/scripts/main.py
@@ -25,6 +25,7 @@ from sparsify.auto.utils import (
 )
 from sparsify.schemas import APIArgs
 from sparsify.schemas.auto_api import SparsificationTrainingConfig
+from sparsify.utils import get_task_info
 from tensorboard.program import TensorBoard
 from tensorboard.util import tb_logging
 
@@ -42,7 +43,7 @@ def main(api_args: APIArgs):
         deploy_directory,
     ) = create_save_directory(api_args)
 
-    if api_args.task == "finetune":
+    if api_args.task in get_task_info("finetune").aliases:
         _LOGGER.info(
             "Running finetuning. "
             "Currently only arguments passed for use-case and data will be considered"

--- a/src/sparsify/auto/tasks/finetune/__init__.py
+++ b/src/sparsify/auto/tasks/finetune/__init__.py
@@ -14,4 +14,5 @@
 
 # flake8: noqa
 
+from .finetune import *
 from .runner import *

--- a/src/sparsify/auto/tasks/finetune/__init__.py
+++ b/src/sparsify/auto/tasks/finetune/__init__.py
@@ -15,5 +15,9 @@
 # flake8: noqa
 
 from .args import *
-from .finetune import *
-from .runner import *
+
+try:
+    from .finetune import *
+    from .runner import *
+except ImportError:
+    raise ImportError("To use the llm finetuning pathway, please install sparsify[llm]")

--- a/src/sparsify/auto/tasks/finetune/__init__.py
+++ b/src/sparsify/auto/tasks/finetune/__init__.py
@@ -16,6 +16,7 @@
 
 from .args import *
 
+
 try:
     from .finetune import *
     from .runner import *

--- a/src/sparsify/auto/tasks/finetune/__init__.py
+++ b/src/sparsify/auto/tasks/finetune/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# flake8: noqa
+
+from .runner import *

--- a/src/sparsify/auto/tasks/finetune/__init__.py
+++ b/src/sparsify/auto/tasks/finetune/__init__.py
@@ -20,5 +20,7 @@ from .args import *
 try:
     from .finetune import *
     from .runner import *
-except ImportError:
-    raise ImportError("To use the llm finetuning pathway, please install sparsify[llm]")
+except ImportError as exception:
+    raise ImportError(
+        "To use the llm finetuning pathway, please install sparsify[llm]"
+    ) from exception

--- a/src/sparsify/auto/tasks/finetune/args.py
+++ b/src/sparsify/auto/tasks/finetune/args.py
@@ -12,8 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# flake8: noqa
+from pydantic import Field
+from sparsify.auto.tasks import BaseArgs
 
-from .args import *
-from .finetune import *
-from .runner import *
+
+__all__ = ["FineTuneTrainArgs"]
+
+
+class FineTuneTrainArgs(BaseArgs):
+    yaml: str = Field(
+        default=None,
+        description="path to the training yaml",
+    )
+    checkpoints: str = Field(
+        default=None,
+        description="path to the directory to store checkpoints",
+    )
+    logging: str = Field(
+        default=None,
+        description="path to store logs",
+    )

--- a/src/sparsify/auto/tasks/finetune/finetune.py
+++ b/src/sparsify/auto/tasks/finetune/finetune.py
@@ -47,7 +47,7 @@ TEXT_DENOISING_MODELS = ["hf_prefix_lm", "hf_t5"]
 TEXT_MODELS = ["hf_causal_lm"]
 
 
-class Datatypes(Enum):
+class LLMDataTypes(Enum):
     TEXT = "text"
     TEXT_DENOISING = "text_denoising"
     FINETUNING = "finetuning"
@@ -73,7 +73,7 @@ class FineTuner:
         """
         :param dataset_path: path to the llmfoundry compliant yaml file
         :param train_directory: path to log the checkpoints for the model
-        :paral log_dir: path to store the specified logger (such as tensorboard)
+        :param log_dir: path to store the specified logger (such as tensorboard)
 
         """
         if os.path.exists(dataset_path):
@@ -123,14 +123,14 @@ class FineTuner:
             data_loaders.append(self._train_config.get("eval_loader"))
 
         for loader in data_loaders:
-            if loader["name"] == Datatypes.TEXT.value:
+            if loader["name"] == LLMDataTypes.TEXT.value:
                 if self.model_name in TEXT_DENOISING_MODELS:
                     raise ValueError(
                         f"Model type {self.model_name} is not supported "
                         " for text dataloaders. Please use the "
                         " text_denoising dataloader."
                     )
-            elif loader["name"] == Datatypes.TEXT_DENOISING.value:
+            elif loader["name"] == LLMDataTypes.TEXT_DENOISING.value:
                 if self.model_name in TEXT_MODELS:
                     raise ValueError(
                         f"Model type {self.model_name} is not supported "
@@ -145,7 +145,7 @@ class FineTuner:
         :param tokenizer: transformers tokenizer
         :return: HuggingFaceModel from the mosaicml composer library
         """
-        if not COMPOSER_MODEL_REGISTRY.get(self.model_name):
+        if self.model_name not in COMPOSER_MODEL_REGISTRY:
             raise ValueError(
                 "Please ensure the model name provided is one of "
                 f" {list(COMPOSER_MODEL_REGISTRY.keys())}"
@@ -166,24 +166,24 @@ class FineTuner:
         for the dataloader.
 
         :param dataloader_config DictConfig from the omegaconf library, containing
-        details on the dataloader
+            details on the dataloader
         :param tokenizer: transformers tokenizer
         :param device_batch_size: batch size for the dataloader
         :return: a torch DataLoader
         """
-        if dataloader_config.name == Datatypes.TEXT.value:
+        if dataloader_config.name == LLMDataTypes.TEXT.value:
             return build_text_dataloader(
                 dataloader_config,
                 tokenizer,
                 device_batch_size,
             )
-        elif dataloader_config.name == Datatypes.TEXT_DENOISING.value:
+        elif dataloader_config.name == LLMDataTypes.TEXT_DENOISING.value:
             return build_text_denoising_dataloader(
                 dataloader_config,
                 tokenizer,
                 device_batch_size,
             )
-        elif dataloader_config.name == Datatypes.FINETUNING.value:
+        elif dataloader_config.name == LLMDataTypes.FINETUNING.value:
             return build_finetuning_dataloader(
                 dataloader_config,
                 tokenizer,

--- a/src/sparsify/auto/tasks/finetune/finetune.py
+++ b/src/sparsify/auto/tasks/finetune/finetune.py
@@ -276,11 +276,21 @@ class FineTuner:
         trainer.fit()
 
 
-def main():
+# trainhook
+def main(
+    yaml_path: Union[str, Path],
+    train_directory: Union[str, Path],
+    log_dir: Union[str, Path],
+):
+    finetuner = FineTuner(yaml_path, train_directory, log_dir)
+    finetuner.fine_tune()
+
+
+# for ddp training
+def parse_args_and_run():
     yaml_path, train_directory, log_dir = (
         sys.argv[1],
         sys.argv[2],
         sys.argv[3],
     )  # hackey; add args eventually
-    finetuner = FineTuner(yaml_path, train_directory, log_dir)
-    finetuner.fine_tune()
+    main(yaml_path, train_directory, log_dir)

--- a/src/sparsify/auto/tasks/finetune/helpers.py
+++ b/src/sparsify/auto/tasks/finetune/helpers.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from composer.core import Algorithm, Event
+
+
+all = ["attach_masks", "MaskPrunedWeights"]
+
+
+class MaskPrunedWeights(Algorithm):
+    """
+    Composer specific hook which allows us to mask weights after a specific event,
+    in this case at the end of the batch. Provided as input to the Trainer while
+    finetuning. Note: can also mask weights before the forward pass by adding
+    `or event == Event.BATCH_START`
+    """
+
+    def match(self, event, state):
+        return event == Event.BATCH_END
+
+    @torch.no_grad()
+    def apply(self, event, state, logger):
+        def mask_weights(module):
+            if hasattr(module, "constant_pruning_mask"):
+                module.weight *= module.constant_pruning_mask
+
+        state.model.apply(mask_weights)
+
+
+def attach_masks(model: torch.nn.Module):
+    """
+    Recursively attach masks to weights which have already been pruned to avoid
+    finetuning them further.
+
+    :param model: torch.nnn.Module to recursively attach masks to if the weights are
+    already pruned
+    """
+    for _, module in model.named_children():
+        if isinstance(module, torch.nn.Linear):
+            constant_pruning_mask = torch.where(
+                module.weight == 0,
+                torch.tensor(0, dtype=torch.uint8),
+                torch.tensor(1, dtype=torch.uint8),
+            )
+            module.register_buffer(
+                "constant_pruning_mask", constant_pruning_mask, persistent=False
+            )
+        else:
+            attach_masks(module)

--- a/src/sparsify/auto/tasks/finetune/runner.py
+++ b/src/sparsify/auto/tasks/finetune/runner.py
@@ -46,7 +46,6 @@ class LLMFinetuner(TaskRunner):
     def config_to_args(
         cls, config: SparsificationTrainingConfig
     ) -> Tuple[BaseModel, BaseModel]:
-
         train_args = FineTuneTrainArgs(yaml=config.dataset)
 
         return train_args, None

--- a/src/sparsify/auto/tasks/finetune/runner.py
+++ b/src/sparsify/auto/tasks/finetune/runner.py
@@ -15,6 +15,7 @@
 from typing import Tuple
 
 from pydantic import BaseModel
+from sparsify.auto.tasks.finetune.args import FineTuneTrainArgs
 from sparsify.auto.tasks.finetune.finetune import main as train_hook
 from sparsify.auto.tasks.runner import TaskRunner
 from sparsify.auto.utils import HardwareSpecs
@@ -45,7 +46,10 @@ class LLMFinetuner(TaskRunner):
     def config_to_args(
         cls, config: SparsificationTrainingConfig
     ) -> Tuple[BaseModel, BaseModel]:
-        return None, None
+
+        train_args = FineTuneTrainArgs(yaml=config.dataset)
+
+        return train_args, None
 
     def update_run_directory_args(self):
         pass

--- a/src/sparsify/auto/tasks/finetune/runner.py
+++ b/src/sparsify/auto/tasks/finetune/runner.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Tuple
+
+from pydantic import BaseModel
+from sparsify.auto.tasks.runner import TaskRunner
+from sparsify.auto.utils import HardwareSpecs
+from sparsify.schemas import Metrics, SparsificationTrainingConfig
+from sparsify.utils import TASK_REGISTRY
+
+
+__all__ = [
+    "LLMFinetuner",
+]
+
+
+@TaskRunner.register_task(task=TASK_REGISTRY["finetune"])
+class LLMFinetuner(TaskRunner):
+    export_model_kwarg = "None"
+
+    def __init__(self, config: SparsificationTrainingConfig):
+        super().__init__(config)
+        self.train_config = config.dataset
+
+    @classmethod
+    def config_to_args(
+        cls, config: SparsificationTrainingConfig
+    ) -> Tuple[BaseModel, BaseModel]:
+        return None, None
+
+    def update_run_directory_args(self):
+        pass
+
+    def _train_completion_check(self) -> bool:
+        pass
+
+    def _export_completion_check(self) -> bool:
+        pass
+
+    def _update_train_args_post_failure(self, error_type: Exception):
+        pass
+
+    def _update_export_args_post_failure(self, error_type: Exception):
+        pass
+
+    def _get_metrics(self) -> Metrics:
+        pass
+
+    def _get_default_deployment_directory(self, train_directory: str) -> str:
+        pass
+
+    def tune_args_for_hardware(self, hardware_specs: HardwareSpecs):
+        pass

--- a/src/sparsify/auto/tasks/finetune/runner.py
+++ b/src/sparsify/auto/tasks/finetune/runner.py
@@ -15,6 +15,7 @@
 from typing import Tuple
 
 from pydantic import BaseModel
+from sparsify.auto.tasks.finetune.finetune import main as train_hook
 from sparsify.auto.tasks.runner import TaskRunner
 from sparsify.auto.utils import HardwareSpecs
 from sparsify.schemas import Metrics, SparsificationTrainingConfig
@@ -28,11 +29,17 @@ __all__ = [
 
 @TaskRunner.register_task(task=TASK_REGISTRY["finetune"])
 class LLMFinetuner(TaskRunner):
+    """
+    TaskRunner for LLM finetuning. Currently set-up as a shell to leverage TaskRunner's
+    ddp functionality for finetuning. Function definitions will be completed as
+    functionality is further supported.
+    """
+
+    train_hook = staticmethod(train_hook)
     export_model_kwarg = "None"
 
     def __init__(self, config: SparsificationTrainingConfig):
         super().__init__(config)
-        self.train_config = config.dataset
 
     @classmethod
     def config_to_args(

--- a/src/sparsify/auto/tasks/runner.py
+++ b/src/sparsify/auto/tasks/runner.py
@@ -30,7 +30,7 @@ from torch.distributed.run import main as launch_ddp
 from pydantic import BaseModel
 from sparsify.auto.utils import ErrorHandler, HardwareSpecs, analyze_hardware
 from sparsify.schemas import Metrics, SparsificationTrainingConfig
-from sparsify.utils import TASK_REGISTRY, TaskName
+from sparsify.utils import TASK_REGISTRY, TaskName, get_task_info
 
 
 __all__ = [
@@ -272,7 +272,7 @@ class TaskRunner:
             "auto",
             f"--master_port={_get_open_port_()}",
         ]
-        if self._config.task == "finetune":
+        if self._config.task in get_task_info("finetune").aliases:
             ddp_args += [
                 "finetune",
                 f"{self._config.dataset}",
@@ -290,8 +290,7 @@ class TaskRunner:
         """
         Run training through sparseml hook
         """
-
-        if self._config.task == "finetune":
+        if self._config.task in get_task_info("finetune").aliases:
             self.train_hook(
                 self._config.dataset, self.run_directory, self.log_directory
             )
@@ -520,10 +519,7 @@ def _dynamically_register_integration_runner(task: str):
         from sparsify.auto.tasks.image_classification import (  # noqa F401
             ImageClassificationRunner,
         )
-    elif (
-        TASK_REGISTRY[task].domain == "llm"
-        and TASK_REGISTRY[task].sub_domain == "language_modeling"
-    ):
+    elif TASK_REGISTRY[task].domain == "llm":
         from sparsify.auto.tasks.finetune import LLMFinetuner  # noqa F401
     else:
         raise ValueError(

--- a/src/sparsify/auto/tasks/runner.py
+++ b/src/sparsify/auto/tasks/runner.py
@@ -275,7 +275,7 @@ class TaskRunner:
         if self._config.task == "finetune":
             ddp_args += [
                 "finetune",
-                f"{self.train_config}",
+                f"{self._config.dataset}",
                 f"{self.run_directory}",
                 f"{self.log_directory}",
             ]
@@ -290,7 +290,13 @@ class TaskRunner:
         """
         Run training through sparseml hook
         """
-        self.train_hook(**self.train_args.dict())
+
+        if self._config.task == "finetune":
+            self.train_hook(
+                self._config.dataset, self.run_directory, self.log_directory
+            )
+        else:
+            self.train_hook(**self.train_args.dict())
 
     def train(self, train_directory: str, log_directory: str) -> Metrics:
         """

--- a/src/sparsify/auto/tasks/transformers/__init__.py
+++ b/src/sparsify/auto/tasks/transformers/__init__.py
@@ -15,5 +15,17 @@
 # flake8: noqa
 # isort: skip_file
 
+
+def _check_nm_install():
+    try:
+        from .runner import *
+    except ImportError as exception:
+        raise ImportError(
+            "Please install sparsify[nm] to use this pathway."
+        ) from exception
+
+
+_check_nm_install()
+
 from .args import *
 from .runner import *

--- a/src/sparsify/auto/utils/error_handler.py
+++ b/src/sparsify/auto/utils/error_handler.py
@@ -154,7 +154,7 @@ class ErrorHandler:
             if all(
                 [
                     (
-                        (type(error) == type(first_error))
+                        (type(error) is type(first_error))
                         and (error.args == first_error.args)
                     )
                     for error in self._caught_runtime_errors

--- a/src/sparsify/schemas/auto_api.py
+++ b/src/sparsify/schemas/auto_api.py
@@ -160,14 +160,14 @@ class SparsificationTrainingConfig(BaseModel):
     dataset: str = Field(
         description="path to the dataset to train the task on",
     )
-    base_model: str = Field(
+    base_model: Union[str, None] = Field(
         description="path to the model to be sparsified",
     )
     distill_teacher: str = Field(
         description="optional path to a distillation teacher for training",
         default="auto",
     )
-    recipe: str = Field(
+    recipe: Union[str, None] = Field(
         description="file path to or zoo stub of sparsification recipe to be applied",
     )
     recipe_args: Dict[str, Any] = Field(

--- a/src/sparsify/schemas/auto_api.py
+++ b/src/sparsify/schemas/auto_api.py
@@ -160,14 +160,14 @@ class SparsificationTrainingConfig(BaseModel):
     dataset: str = Field(
         description="path to the dataset to train the task on",
     )
-    base_model: Union[str, None] = Field(
+    base_model: Optional[str] = Field(
         description="path to the model to be sparsified",
     )
     distill_teacher: str = Field(
         description="optional path to a distillation teacher for training",
         default="auto",
     )
-    recipe: Union[str, None] = Field(
+    recipe: Optional[str] = Field(
         description="file path to or zoo stub of sparsification recipe to be applied",
     )
     recipe_args: Dict[str, Any] = Field(

--- a/src/sparsify/utils/constants.py
+++ b/src/sparsify/utils/constants.py
@@ -50,6 +50,12 @@ DEPLOYMENT_SCENARIOS = [
 ]
 
 TASK_REGISTRY: Dict[str, TaskName] = {
+    "finetune": TaskName(
+        name="finetune",
+        aliases=["finetuning", "fine tune"],
+        domain="nlp",
+        sub_domain="language_modeling",
+    ),
     "image_classification": TaskName(
         name="image_classification",
         aliases=["ic", "classification", "cv_classification"],

--- a/src/sparsify/utils/constants.py
+++ b/src/sparsify/utils/constants.py
@@ -53,7 +53,7 @@ TASK_REGISTRY: Dict[str, TaskName] = {
     "finetune": TaskName(
         name="finetune",
         aliases=["finetuning", "fine tune"],
-        domain="nlp",
+        domain="llm",
         sub_domain="language_modeling",
     ),
     "image_classification": TaskName(


### PR DESCRIPTION
## Summary

- Enable LLM finetuning in sparsify by adding support for the llmfoundry library
- This is done by adding an additional task called `finetune` which provides support for all the steps required for llmfoundry finetuning integration 
- Currently, this workflow launches finetuning given a llfoundry compliant yaml file (provided using the `--data` cli arg to the sparsify command)
- Exporting steps are currently skipped and as there is no sparseml support atm, in order to allow ddp training, `finetune.py` includes the steps which can be wrapped in `launch_ddp` and `trainhook`
- As the only essential arg is the `data` arg containing the yaml file, there are no `finetune` specific train args but this can be added in as greater finetuneing support is flushed out

## Testing

- A sample yaml can be found under the new `samples` folder
- Tested locally using both 1 GPU and for DDP Training
- The following command was used for testing:

```
sparsify.run sparse-transfer --use-case finetune --data ../src/sparsify/auto/samples/finetune_llmfoundry_sample.yaml
```

This produces the following output in the running directory after training is complete.
`sparse_transfer_finetune_2023_08_09_01_24_08`

All paths from llmfoundry are updated to use the working directory as the root and therefore, the output directory shown above contains the checkpoints and all other llmfoundry-specific outputs.