### PR TITLE
LLM finetune sparsify masking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,7 @@ _dev_deps = [
 
 _llm_deps = [
     "llm-foundry==0.2.0",
-    f"{'nm-transformers' if is_release else 'nm-transformers-nightly'}",
-    "flash_attn"
+    f"{'nm-transformers' if is_release else 'nm-transformers-nightly'}"
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,9 @@ version_major_minor = version
 # load and overwrite version and release info from sparseml package
 exec(open(os.path.join("src", "sparsify", "version.py")).read())
 print(f"loaded version {version} from src/sparsify/version.py")
-version_nm_deps = f"{version_major_minor}.0"
+version_nm_deps = f"{version_major_minor}.0.202308"
 
 _PACKAGE_NAME = "sparsify" if is_release else "sparsify-nightly"
-
 
 _deps = [
     "pydantic>=1.8.2,<2.0.0",
@@ -39,13 +38,14 @@ _deps = [
     "setuptools>=56.0.0",
     "optuna>=3.0.2",
     "onnxruntime-gpu",
-]
-_nm_deps = [
     f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_nm_deps}",
-    f"{'sparseml' if is_release else 'sparseml-nightly'}[torchvision,transformers,yolov5]~={version_nm_deps}",  # noqa E501
     f"{'deepsparse' if is_release else 'deepsparse-nightly'}~={version_nm_deps}",
+    f"{'sparseml' if is_release else 'sparseml-nightly'}[torchvision,yolov5]~={version_nm_deps}"
 ]
 
+_nm_deps = [
+    f"{'sparseml' if is_release else 'sparseml-nightly'}[transformers]~={version_nm_deps}",  # noqa E501
+]
 
 _dev_deps = [
     "black>=20.8b1",
@@ -56,7 +56,11 @@ _dev_deps = [
     "fastai>=2.7.7",
 ]
 
-_llm_deps = ["llm-foundry==0.2.0"]
+_llm_deps = [
+    "llm-foundry==0.2.0",
+    f"{'nm-transformers' if is_release else 'nm-transformers-nightly'}",
+    "flash_attn"
+]
 
 
 def _setup_packages() -> List:
@@ -70,11 +74,11 @@ def _setup_package_dir() -> Dict:
 
 
 def _setup_install_requires() -> List:
-    return _nm_deps + _deps
+    return _deps
 
 
 def _setup_extras() -> Dict:
-    return {"dev": _dev_deps, "llm": _llm_deps}
+    return {"dev": _dev_deps, "_nm_deps": _nm_deps, "llm": _llm_deps}
 
 
 def _setup_entry_points() -> Dict:

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ _deps = [
     "onnxruntime-gpu",
     f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_nm_deps}",
     f"{'deepsparse' if is_release else 'deepsparse-nightly'}~={version_nm_deps}",
-    f"{'sparseml' if is_release else 'sparseml-nightly'}[torchvision,yolov5]~={version_nm_deps}"
+    f"{'sparseml' if is_release else 'sparseml-nightly'}[torchvision,yolov5]~={version_nm_deps}",  # noqa E501
 ]
 
 _nm_deps = [
@@ -58,7 +58,7 @@ _dev_deps = [
 
 _llm_deps = [
     "llm-foundry==0.2.0",
-    f"{'nm-transformers' if is_release else 'nm-transformers-nightly'}"
+    f"{'nm-transformers' if is_release else 'nm-transformers-nightly'}",
 ]
 
 

--- a/src/sparsify/auto/samples/finetune_llmfoundry_sample.yaml
+++ b/src/sparsify/auto/samples/finetune_llmfoundry_sample.yaml
@@ -1,4 +1,4 @@
-max_seq_len: 128
+max_seq_len: 2048
 global_seed: 17
 model_name_or_path: mosaicml/mpt-7b-instruct
 load_path:  /storage/dsikka/mpt_7b_instruct_oneshot_sp70.pt
@@ -26,7 +26,7 @@ run_name: test_run
 
 model:
   name: hf_causal_lm
-  pretrained: false
+  pretrained: true
   pretrained_model_name_or_path: mosaicml/mpt-7b-instruct
   max_seq_len: ${max_seq_len}
   config_overrides:
@@ -70,7 +70,7 @@ eval_loader:
     max_seq_len: ${max_seq_len}
     allow_pad_trimming: false
     decoder_only_format: true
-    packing_ratio: 20
+    packing_ratio: 13
     shuffle: false
   drop_last: false
   num_workers: 8

--- a/src/sparsify/auto/samples/finetune_llmfoundry_sample.yaml
+++ b/src/sparsify/auto/samples/finetune_llmfoundry_sample.yaml
@@ -1,32 +1,43 @@
-max_seq_len: 512
+max_seq_len: 128
 global_seed: 17
-model_name_or_path: t5-small
-model_name: ${model_name_or_path}
-load_path:  # set via bash script to be absolute path to your sparse checkpoint
+model_name_or_path: mosaicml/mpt-7b-instruct
+load_path:  /storage/dsikka/mpt_7b_instruct_oneshot_sp70.pt
 precision: amp_bf16
 
-max_duration: 1ep # run for 2 epochs
+max_duration: 1ep
 eval_interval: 1ep
 # eval_subset_num_batches: 3  # use this for quick testing
 eval_first: true
 seed: ${global_seed}
 
-device_train_microbatch_size: 1 # set to catch potential OOM cuda errors
-device_train_batch_size: 4
-device_eval_batch_size: 4
+global_train_batch_size: 1
+# for mpt-7b dense:
+# 4 x A100_80GB = "device_train_microbatch_size: 12"
+# 8 x A6000_48GB = "device_train_microbatch_size: 6"
+
+# for mpt-7b sparse (with masks):
+# 8 x A6000_48GB = "device_train_microbatch_size: 4"
+device_train_batch_size: 1
+device_train_microbatch_size: 1
+device_eval_batch_size: 1
 
 # Run Name
-run_name: testing_run
+run_name: test_run
 
 model:
-  name: hf_t5
-  pretrained: true
-  pretrained_model_name_or_path: t5-small
+  name: hf_causal_lm
+  pretrained: false
+  pretrained_model_name_or_path: mosaicml/mpt-7b-instruct
   max_seq_len: ${max_seq_len}
+  config_overrides:
+    attn_config:
+      attn_impl: torch
+      # Set this to `true` if using `train_loader.dataset.packing_ratio` below
+      attn_uses_sequence_id: true
 
 # Tokenizer
 tokenizer:
-  name: ${model_name}
+  name: EleutherAI/gpt-neox-20b
   kwargs:
     model_max_length: ${max_seq_len}
 
@@ -59,7 +70,7 @@ eval_loader:
     max_seq_len: ${max_seq_len}
     allow_pad_trimming: false
     decoder_only_format: true
-    packing_ratio: 13
+    packing_ratio: 20
     shuffle: false
   drop_last: false
   num_workers: 8
@@ -83,6 +94,14 @@ optimizer:
   eps: 1.0e-8
   weight_decay: 0.0
 
+# we can't use gradient clipping for sparse training runs because we don't have
+# a way to mask gradients of pruned weights, and thus the global gradient norm
+# will be incorrect
+# algorithms:
+#   gradient_clipping:
+#     clipping_type: norm
+#     clipping_threshold: 1.0
+
 # FSDP
 fsdp_config:
   sharding_strategy: FULL_SHARD
@@ -98,8 +117,15 @@ progress_bar: false
 log_to_console: true
 console_log_interval: 1ba
 
+callbacks:
+  speed_monitor:
+    window_size: 10
+  lr_monitor: {}
+  memory_monitor: {}
+  runtime_estimator: {}
+
 loggers:
-  tensorboard: {"log_dir": "my_logs"}
+  tensorboard: {}
 
 # Checkpoint to local filesystem or remote object store
 save_interval: 1ep

--- a/src/sparsify/auto/tasks/finetune/finetune.py
+++ b/src/sparsify/auto/tasks/finetune/finetune.py
@@ -182,7 +182,7 @@ class FineTuner:
             )
         except Exception as e:
             _LOGGER.error(f" Failed to load weights. Returning pretrained model {e}")
-            if self._train_config.model.pretrained == False:
+            if self._train_config.model.pretrained is False:
                 self._train_config.model.pretrained = True
                 model = self._build_model(tokenizer)
             return model, None

--- a/src/sparsify/auto/tasks/finetune/finetune.py
+++ b/src/sparsify/auto/tasks/finetune/finetune.py
@@ -38,6 +38,7 @@ from llmfoundry.utils.builders import (
     build_scheduler,
     build_tokenizer,
 )
+from llmfoundry.utils.config_utils import update_batch_size_info
 from omegaconf import DictConfig
 from omegaconf import OmegaConf as om
 from sparsify.auto.tasks.finetune.helpers import MaskPrunedWeights, attach_masks
@@ -253,6 +254,9 @@ class FineTuner:
         reproducibility.seed_all(self._train_config.seed)
         if dist.get_world_size() > 1:
             dist.initialize_dist(get_device(None))
+
+        self._train_config = update_batch_size_info(self._train_config)
+
         tokenizer = build_tokenizer(self._train_config.tokenizer)
 
         algorithms = []

--- a/src/sparsify/auto/tasks/finetune/helpers.py
+++ b/src/sparsify/auto/tasks/finetune/helpers.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from composer.core import Algorithm, Event
+
+
+all = ["attach_masks", "MaskPrunedWeights"]
+
+
+class MaskPrunedWeights(Algorithm):
+    """
+    Composer specific hook which allows us to mask weights after a specific event,
+    in this case at the end of the batch. Provided as input to the Trainer while
+    finetuning. Note: can also mask weights before the forward pass by adding
+    `or event == Event.BATCH_START`
+    """
+
+    def match(self, event, state):
+        return event == Event.BATCH_END
+
+    @torch.no_grad()
+    def apply(self, event, state, logger):
+        def mask_weights(module):
+            if hasattr(module, "mask"):
+                module.weight *= module.mask
+
+        state.model.apply(mask_weights)
+
+
+def attach_masks(model: torch.nn.Module):
+    """
+    Recursively attach masks to weights which have already been pruned to avoid
+    finetuning them further.
+
+    :param model: torch.nnn.Module to recursively attach masks to if the weights are
+    already pruned
+    """
+    for _, module in model.named_children():
+        if isinstance(module, torch.nn.Linear):
+            mask = torch.where(
+                module.weight == 0,
+                torch.tensor(0, dtype=torch.uint8),
+                torch.tensor(1, dtype=torch.uint8),
+            )
+            module.register_buffer("mask", mask, persistent=False)
+        else:
+            attach_masks(module)

--- a/src/sparsify/auto/tasks/transformers/__init__.py
+++ b/src/sparsify/auto/tasks/transformers/__init__.py
@@ -15,5 +15,17 @@
 # flake8: noqa
 # isort: skip_file
 
+
+def _check_nm_install():
+    try:
+        from .runner import *
+    except ImportError as exception:
+        raise ImportError(
+            "Please install sparsify[nm] to use this pathway."
+        ) from exception
+
+
+_check_nm_install()
+
 from .args import *
 from .runner import *


### PR DESCRIPTION
## Summary:

Add helper functions to the `finetune` task which allows us to finetune previously sparsified models. This is done by attaching masks using buffers after the sparsified model is loaded, to any weight which has already been pruned. A Composer callback function is also added to apply the masks to the weights, after each step during training. These helper functions will be converted to be applied through a recipe in a follow-up PR.

## Package Updates

llm-foundry has a requirement for `accelerate` which is incompatible with our transformers. Therefore, this moves `sparseml[transformers]` to the `nm` tag instead of making it a required installation. This allows us to install the correct `accelerate` for `llm-foundry` with the `llm` tag and the correct `accelerate` for `sparseml[transformers]` with the `nm` tag. Also, because our requirements are broad, there is an issue with older nightly versions. `setup.py` has been updated to look at more recent versions.


## Testing:

Testing using a 70% sparsified mpt model. The following command and config was used for this model:

```
max_seq_len: 2048
global_seed: 17
model_name_or_path: mosaicml/mpt-7b-instruct
model_name: ${model_name_or_path}
load_path:  /home/dsikka/mpt_7b_instruct_oneshot_sp70.pt
precision: amp_bf16

max_duration: 1ep # run for 2 epochs
eval_interval: 1ep
# eval_subset_num_batches: 3  # use this for quick testing
eval_first: true
seed: ${global_seed}

device_train_microbatch_size: 1 # set to catch potential OOM cuda errors
device_train_batch_size: 4
device_eval_batch_size: 4

# Run Name
run_name: testing_run

model:
  name: hf_causal_lm
  pretrained: true
  pretrained_model_name_or_path: ${model_name}
  max_seq_len: ${max_seq_len}

# Tokenizer
tokenizer:
  name: ${model_name}
  kwargs:
    model_max_length: ${max_seq_len}

# Dataloaders
train_loader:
  name: finetuning
  dataset:
    hf_name: mosaicml/dolly_hhrlhf
    split: train
    max_seq_len: ${max_seq_len}
    allow_pad_trimming: false
    decoder_only_format: true
    # # Use `python llmfoundry/data/packing.py --yaml-path /path/to/this/yaml/ ...`
    # # to profile this run's optimal packing_ratio as it depends on GPU count,
    # # batch size, sequence length
    packing_ratio: 13 # padding=0.36%, waste=0.79%
    shuffle: true
  drop_last: false
  num_workers: 8
  pin_memory: false
  prefetch_factor: 2
  persistent_workers: true
  timeout: 0

eval_loader:
  name: finetuning
  dataset:
    hf_name: mosaicml/dolly_hhrlhf
    split: test
    max_seq_len: ${max_seq_len}
    allow_pad_trimming: false
    decoder_only_format: true
    packing_ratio: 13
    shuffle: false
  drop_last: false
  num_workers: 8
  pin_memory: false
  prefetch_factor: 2
  persistent_workers: true
  timeout: 0

# Optimization
scheduler:
  name: linear_decay_with_warmup
  t_warmup: 20ba
  alpha_f: 0

optimizer:
  name: decoupled_adamw
  lr: 1e-4
  betas:
  - 0.9
  - 0.999
  eps: 1.0e-8
  weight_decay: 0.0

# FSDP
fsdp_config:
  sharding_strategy: FULL_SHARD
  mixed_precision: FULL
  activation_checkpointing: true
  activation_checkpointing_reentrant: false
  activation_cpu_offload: false
  limit_all_gathers: true
  verbose: false

# Logging
progress_bar: false
log_to_console: true
console_log_interval: 1ba

loggers:
  tensorboard: {"log_dir": "my_logs"}

# Checkpoint to local filesystem or remote object store
save_interval: 1ep
save_num_checkpoints_to_keep: 1  # Important, this cleans up checkpoints saved to DISK
save_folder: output_dir/{run_name}/checkpoints
save_overwrite: true
```

This was tested using the following command:

```
sparsify.run sparse-transfer --use-case finetune --data ../src/sparsify/auto/samples/finetune_llmfoundry_sample.yaml
```