### PR TITLE
[BugFix] Point readme to updated dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Or, to sparsify a BERT model on the SST2 dataset for sentiment analysis, run the
 ```bash
 wget https://public.neuralmagic.com/datasets/nlp/text_classification/sst2_bert_calibration.tar.gz
 tar -xzf sst2_bert_calibration.tar.gz
-sparsify.run one-shot --use-case text_classification --model "zoo:nlp/sentiment_analysis/bert-base/pytorch/huggingface/sst2/base-none" --data --data ./sst2_bert_calibration/sst2.hf --optim-level 0.5
+sparsify.run one-shot --use-case text_classification --model "zoo:nlp/sentiment_analysis/bert-base/pytorch/huggingface/sst2/base-none" --data --data ./sst2_bert_calibration --optim-level 0.5
 ```
 
 To dive deeper into One-Shot Experiments, read through the [One-Shot Experiment Guide](https://github.com/neuralmagic/sparsify/blob/main/docs/one-shot-experiment-guide.md).

--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ sparsify.run one-shot --use-case image_classification --model "zoo:cv/classifica
 
 Or, to sparsify a BERT model on the SST2 dataset for sentiment analysis, run the following commands:
 ```bash
-wget https://public.neuralmagic.com/datasets/nlp/text_classification/sst2_calibration.tar.gz
-tar -xzf sst2_calibration.tar.gz
-sparsify.run one-shot --use-case text_classification --model "zoo:nlp/sentiment_analysis/bert-base/pytorch/huggingface/sst2/base-none" --data --data ./sst2_calibration/sst2.hf --optim-level 0.5
+wget https://public.neuralmagic.com/datasets/nlp/text_classification/sst2_bert_calibration.tar.gz
+tar -xzf sst2_bert_calibration.tar.gz
+sparsify.run one-shot --use-case text_classification --model "zoo:nlp/sentiment_analysis/bert-base/pytorch/huggingface/sst2/base-none" --data --data ./sst2_bert_calibration/sst2.hf --optim-level 0.5
 ```
 
 To dive deeper into One-Shot Experiments, read through the [One-Shot Experiment Guide](https://github.com/neuralmagic/sparsify/blob/main/docs/one-shot-experiment-guide.md).


### PR DESCRIPTION
The link mentioned previously downloaded a wrongly generated dataset (it had fewer inputs); the new link and the dataset have been verified to work with the readme command locally

```bash
#!/usr/bin/env bash

export CUDA_VISIBLE_DEVICES=2
export SPARSEZOO_TEST_MODE="true"
export NM_BIND_THREADS_TO_CORES=1
export NM_DISABLE_ANALYTICS=1
sparsify.login XXXXXXXXX
sparsify.run one-shot --use-case text_classification --model "zoo:nlp/sentiment_analysis/bert-base/pytorch/huggingface/sst2/base-none" --data /home/rahul/datasets/sst2_bert_calibration --optim-level 0.5

```