### PR TITLE
[Fix] Release Build trying to install dated versions of nm_deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,9 @@ version_major_minor = version
 # load and overwrite version and release info from sparseml package
 exec(open(os.path.join("src", "sparsify", "version.py")).read())
 print(f"loaded version {version} from src/sparsify/version.py")
-version_nm_deps = f"{version_major_minor}.0.202308"
+version_nm_deps = (
+    version_major_minor if is_release else f"{version_major_minor}.0.202308"
+)
 
 _PACKAGE_NAME = "sparsify" if is_release else "sparsify-nightly"
 
@@ -37,14 +39,13 @@ _deps = [
     "tensorboard>=2.0.0",
     "setuptools>=56.0.0",
     "optuna>=3.0.2",
-    "onnxruntime-gpu",
-    f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_nm_deps}",
-    f"{'deepsparse' if is_release else 'deepsparse-nightly'}~={version_nm_deps}",
-    f"{'sparseml' if is_release else 'sparseml-nightly'}[torchvision,yolov5]~={version_nm_deps}",  # noqa E501
+    "onnxruntime",
 ]
 
 _nm_deps = [
-    f"{'sparseml' if is_release else 'sparseml-nightly'}[transformers]~={version_nm_deps}",  # noqa E501
+    f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_nm_deps}",
+    f"{'deepsparse' if is_release else 'deepsparse-nightly'}~={version_nm_deps}",
+    f"{'sparseml' if is_release else 'sparseml-nightly'}[torchvision,yolov5]~={version_nm_deps}",  # noqa E501
 ]
 
 _dev_deps = [
@@ -73,7 +74,7 @@ def _setup_package_dir() -> Dict:
 
 
 def _setup_install_requires() -> List:
-    return _deps
+    return _nm_deps + _deps
 
 
 def _setup_extras() -> Dict:

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ _deps = [
     "tensorboard>=2.0.0",
     "setuptools>=56.0.0",
     "optuna>=3.0.2",
-    "onnxruntime",
+    "onnxruntime-gpu",
 ]
 
 _nm_deps = [


### PR DESCRIPTION
Append date to major_minor_version only when building a nightly wheel

Tested by setting is_release to True
Also moves Neural Magic dependencies to _nm_deps as is the case for  our other repos