### PR TITLE
[Cherry pick] release version bugfix (#290)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,9 @@ version_major_minor = version
 # load and overwrite version and release info from sparseml package
 exec(open(os.path.join("src", "sparsify", "version.py")).read())
 print(f"loaded version {version} from src/sparsify/version.py")
-version_nm_deps = f"{version_major_minor}.0.202308"
+version_nm_deps = (
+    version_major_minor if is_release else f"{version_major_minor}.0.202308"
+)
 
 _PACKAGE_NAME = "sparsify" if is_release else "sparsify-nightly"
 
@@ -37,14 +39,13 @@ _deps = [
     "tensorboard>=2.0.0",
     "setuptools>=56.0.0",
     "optuna>=3.0.2",
-    "onnxruntime-gpu",
-    f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_nm_deps}",
-    f"{'deepsparse' if is_release else 'deepsparse-nightly'}~={version_nm_deps}",
-    f"{'sparseml' if is_release else 'sparseml-nightly'}[torchvision,yolov5]~={version_nm_deps}",  # noqa E501
+    "onnxruntime",
 ]
 
 _nm_deps = [
-    f"{'sparseml' if is_release else 'sparseml-nightly'}[transformers]~={version_nm_deps}",  # noqa E501
+    f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_nm_deps}",
+    f"{'deepsparse' if is_release else 'deepsparse-nightly'}~={version_nm_deps}",
+    f"{'sparseml' if is_release else 'sparseml-nightly'}[torchvision,yolov5]~={version_nm_deps}",  # noqa E501
 ]
 
 _dev_deps = [
@@ -73,7 +74,7 @@ def _setup_package_dir() -> Dict:
 
 
 def _setup_install_requires() -> List:
-    return _deps
+    return _nm_deps + _deps
 
 
 def _setup_extras() -> Dict:

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ _deps = [
     "tensorboard>=2.0.0",
     "setuptools>=56.0.0",
     "optuna>=3.0.2",
-    "onnxruntime",
+    "onnxruntime-gpu",
 ]
 
 _nm_deps = [


### PR DESCRIPTION
Cherry pick for bug:
 release build asking for dated versions of nm repos, for example asking for `sparsezoo~=1.6.0.202308` instead of `sparsezoo~=1.6.0`

This PR fixes that in 1.6 release 